### PR TITLE
feat(cache): add session persistence for memory cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,17 @@ type = "sqlite"
 path = "./data/dashbrr.db"
 ```
 
+By default, the database file will be created in the same directory as your configuration file. For example:
+
+- If your config is at `/home/user/.config/dashbrr/config.toml`, the database will be at `/home/user/.config/dashbrr/data/dashbrr.db`
+- If your config is at `/etc/dashbrr/config.toml`, the database will be at `/etc/dashbrr/data/dashbrr.db`
+
+You can override this behavior by using the `-db` flag to specify a different database location:
+
+```bash
+dashbrr -config=/etc/dashbrr/config.toml -db=/var/lib/dashbrr/dashbrr.db
+```
+
 ### Environment Variables
 
 For a complete list of available environment variables and their configurations, see our [Environment Variables Documentation](docs/env_vars.md).

--- a/cmd/dashbrr/main.go
+++ b/cmd/dashbrr/main.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -57,9 +58,16 @@ func startServer() {
 		Msg("Starting dashbrr")
 
 	configPath := flag.String("config", "config.toml", "path to config file")
-	dbPath := flag.String("db", "./data/dashbrr.db", "path to database file")
+	var dbPath string
+	flag.StringVar(&dbPath, "db", "", "path to database file")
 	listenAddr := flag.String("listen", ":8080", "address to listen on")
 	flag.Parse()
+
+	// If dbPath wasn't set via flag, use config directory
+	if dbPath == "" {
+		configDir := filepath.Dir(*configPath)
+		dbPath = filepath.Join(configDir, "data", "dashbrr.db")
+	}
 
 	var cfg *config.Config
 	var err error
@@ -77,7 +85,7 @@ func startServer() {
 					ListenAddr: *listenAddr,
 				},
 				Database: config.DatabaseConfig{
-					Path: *dbPath,
+					Path: dbPath,
 				},
 			}
 			log.Warn().Err(err).Msg("Failed to load configuration file, using defaults")

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -2,6 +2,41 @@
 
 This document outlines all available CLI commands in Dashbrr.
 
+## Startup Flags
+
+When starting Dashbrr, you can use the following flags to control its configuration:
+
+```bash
+# Start Dashbrr with default settings
+dashbrr
+
+# Specify a custom config file location
+dashbrr -config=/path/to/config.toml
+
+# Specify a custom database location
+dashbrr -db=/path/to/database.db
+
+# Specify a custom listen address
+dashbrr -listen=:8081
+```
+
+By default:
+
+- The config file is loaded from `./config.toml`
+- The database file is created in the same directory as the config file at `<config_dir>/data/dashbrr.db`
+- The server listens on port 8080
+
+For example:
+
+```bash
+# Using config in /etc/dashbrr
+dashbrr -config=/etc/dashbrr/config.toml
+# Database will be created at /etc/dashbrr/data/dashbrr.db
+
+# Override default database location
+dashbrr -config=/etc/dashbrr/config.toml -db=/var/lib/dashbrr/dashbrr.db
+```
+
 ## Core Commands
 
 ### User Management

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -7,6 +7,18 @@
   - Format: `<host>:<port>`
   - Default: `0.0.0.0:8080`
 
+## Configuration Path
+
+- `DASHBRR__CONFIG_PATH`
+  - Purpose: Path to the configuration file
+  - Default: `config.toml`
+  - Priority: Environment variable > User config directory > Command line flag > Default value
+  - Note: The application will check the following locations for the configuration file:
+    1. The path specified by the `DASHBRR__CONFIG_PATH` environment variable.
+    2. The user config directory (e.g., `~/.config/dashbrr`).
+    3. The current working directory for `config.toml`, `config.yaml`, or `config.yml`.
+    4. The `-config` command line flag can also be used to specify a different path.
+
 ## Cache Configuration
 
 - `CACHE_TYPE`

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -38,6 +38,11 @@
 - `DASHBRR__DB_PATH`
   - Purpose: Path to SQLite database file
   - Example: `/data/dashbrr.db`
+  - Note: If not set, the database will be created in a 'data' subdirectory of the config file's location. This can be overridden by:
+    1. Using the `-db` flag when starting dashbrr
+    2. Setting this environment variable
+    3. Specifying the path in the config file
+  - Priority: Command line flag > Environment variable > Config file > Default location
 
 ### PostgreSQL Configuration
 

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -61,7 +61,7 @@ func (m *AuthMiddleware) RequireAuth() gin.HandlerFunc {
 			sessionKey = fmt.Sprintf("session:%s", sessionToken)
 			err = m.cache.Get(c, sessionKey, &sessionData)
 			if err != nil {
-				log.Error().Err(err).Msg("session not found")
+				log.Debug().Err(err).Msg("session not found")
 				c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid or expired session"})
 				c.Abort()
 				return

--- a/internal/api/routes/routes.go
+++ b/internal/api/routes/routes.go
@@ -34,7 +34,12 @@ func SetupRoutes(r *gin.Engine, db *database.DB, health *services.HealthService)
 		store = cache.NewMemoryStore()
 	}
 
-	log.Debug().Str("type", os.Getenv("CACHE_TYPE")).Msg("Cache initialized")
+	// Determine cache type based on environment and Redis configuration
+	cacheType := "memory"
+	if os.Getenv("CACHE_TYPE") == "redis" && os.Getenv("REDIS_HOST") != "" {
+		cacheType = "redis"
+	}
+	log.Debug().Str("type", cacheType).Msg("Cache initialized")
 
 	// Create rate limiters with different configurations
 	apiRateLimiter := middleware.NewRateLimiter(store, time.Minute, 60, "api:")       // 60 requests per minute for API

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,10 @@ import (
 	"github.com/pelletier/go-toml/v2"
 )
 
+const (
+	EnvConfigPath = "DASHBRR__CONFIG_PATH"
+)
+
 // Config represents the main configuration structure
 type Config struct {
 	Server   ServerConfig   `toml:"server"`

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -22,6 +22,7 @@ import (
 type DB struct {
 	*sql.DB
 	driver string
+	path   string
 }
 
 // Config holds database configuration
@@ -134,7 +135,11 @@ func InitDBWithConfig(config *Config) (*DB, error) {
 		Str("driver", config.Driver).
 		Msg("Successfully connected to database")
 
-	db := &DB{database, config.Driver}
+	db := &DB{
+		DB:     database,
+		driver: config.Driver,
+		path:   config.Path,
+	}
 
 	// Initialize schema
 	if err := db.initSchema(); err != nil {
@@ -142,6 +147,11 @@ func InitDBWithConfig(config *Config) (*DB, error) {
 	}
 
 	return db, nil
+}
+
+// Path returns the database file path (for SQLite)
+func (db *DB) Path() string {
+	return db.path
 }
 
 // initSchema creates the necessary database tables

--- a/internal/services/cache/cache.go
+++ b/internal/services/cache/cache.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -64,11 +63,6 @@ type localCacheItem struct {
 
 // NewCache creates a new Redis cache instance with optimized configuration
 func NewCache(addr string) (Store, error) {
-	// Check if memory cache is explicitly requested
-	if os.Getenv("CACHE_TYPE") == "memory" {
-		return NewMemoryStore(), nil
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 
 	// Development-optimized Redis configuration

--- a/internal/services/cache/memory.go
+++ b/internal/services/cache/memory.go
@@ -43,7 +43,7 @@ type persistedItem struct {
 }
 
 // NewMemoryStore creates a new in-memory cache instance
-func NewMemoryStore() Store {
+func NewMemoryStore(dataDir string) Store {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	store := &MemoryStore{
@@ -52,11 +52,11 @@ func NewMemoryStore() Store {
 		},
 		ctx:         ctx,
 		cancel:      cancel,
-		persistPath: filepath.Join("data", "sessions.json"),
+		persistPath: filepath.Join(dataDir, "sessions.json"),
 	}
 
-	// Ensure data directory exists with proper permissions
-	if err := os.MkdirAll("data", 0700); err != nil {
+	// Ensure directory exists with proper permissions
+	if err := os.MkdirAll(dataDir, 0700); err != nil {
 		log.Error().Err(err).Msg("Failed to create data directory")
 	}
 


### PR DESCRIPTION
# Database Path and Session Persistence Improvements

## Database Path Changes
Makes the database path follow the config path by default, while maintaining flexibility through override options.

### Implementation
- Database file is created in the same directory as the config file by default.
- Can be overridden through:
  - `-db` command line flag (highest priority)
  - `DASHBRR__DB_PATH` environment variable
  - Database path in config file
- Default location (in data subdirectory of config file's location)

### Example
If config is at `/etc/dashbrr/config.toml`, database defaults to `/etc/dashbrr/data/dashbrr.db`.

Can override: `dashbrr -config=/etc/dashbrr/config.toml -db=/var/lib/dashbrr/dashbrr.db`

## Session Persistence
Adds session persistence for the memory cache implementation, allowing sessions to survive application restarts without requiring Redis.

### Why It's Needed
When using the memory cache (without Redis), users were being logged out whenever the application restarted because all session data was lost. This change persists sessions to disk, allowing them to be restored after a restart.

### Implementation
- Sessions are stored alongside the database file (`sessions.json`).
- Works with both:
  - Environment variables: `DASHBRR__DB_PATH`
  - Command line flags: `-db ./data/dashbrr.db`
- Only session data is persisted (not rate limiting or other cache items).
- Uses atomic file operations to prevent corruption.
- Automatically cleans up expired sessions.
- Maintains all session expiration logic.

### Security Considerations
The implementation is secure without encryption because:
- The session file only contains:
  - Session IDs (random tokens)
  - Expiration times
  - Basic metadata (user ID, auth type)
- No passwords, refresh tokens, or OIDC tokens are ever persisted.
- File permissions (0600) ensure only the application user can read the file.
- Sessions still expire at their set time, maintaining security boundaries.

## Testing
- [x] Verified sessions persist across application restarts
- [x] Verified file permissions are correctly set