### PR TITLE
fix: ensure consistent version reporting between startup and version command

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,6 +37,9 @@ builds:
       - -X main.version={{.Version}}
       - -X main.commit={{.Commit}}
       - -X main.date={{.Date}}
+      - -X github.com/autobrr/dashbrr/internal/commands/version.version={{.Version}}
+      - -X github.com/autobrr/dashbrr/internal/commands/version.commit={{.Commit}}
+      - -X github.com/autobrr/dashbrr/internal/commands/version.date={{.Date}}
 
 archives:
   - id: dashbrr

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,14 @@ COPY . ./
 COPY --from=web-builder /app/web/dist ./web/dist
 
 # Build with embedded assets
-RUN go build -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${REVISION} -X main.date=${BUILDTIME}" -o /app/dashbrr cmd/dashbrr/main.go
+RUN go build -ldflags "-s -w \
+    -X main.version=${VERSION} \
+    -X main.commit=${REVISION} \
+    -X main.date=${BUILDTIME} \
+    -X github.com/autobrr/dashbrr/internal/commands/version.version=${VERSION} \
+    -X github.com/autobrr/dashbrr/internal/commands/version.commit=${REVISION} \
+    -X github.com/autobrr/dashbrr/internal/commands/version.date=${BUILDTIME}" \
+    -o /app/dashbrr cmd/dashbrr/main.go
 
 # build runner
 FROM alpine:3.20

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -39,7 +39,14 @@ RUN --network=none --mount=target=. \
     [[ "$GOARCH" == "arm" ]] && [[ "$TARGETVARIANT" == "v6" ]] && export GOARM=6; \
     [[ "$GOARCH" == "arm" ]] && [[ "$TARGETVARIANT" == "v7" ]] && export GOARM=7; \
     echo $GOARCH $GOOS $GOARM$GOAMD64; \
-    go build -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${REVISION} -X main.date=${BUILDTIME}" -o /out/bin/dashbrr cmd/dashbrr/main.go
+    go build -ldflags "-s -w \
+    -X main.version=${VERSION} \
+    -X main.commit=${REVISION} \
+    -X main.date=${BUILDTIME} \
+    -X github.com/autobrr/dashbrr/internal/commands/version.version=${VERSION} \
+    -X github.com/autobrr/dashbrr/internal/commands/version.commit=${REVISION} \
+    -X github.com/autobrr/dashbrr/internal/commands/version.date=${BUILDTIME}" \
+    -o /out/bin/dashbrr cmd/dashbrr/main.go
 
 # build runner
 FROM --platform=$TARGETPLATFORM alpine:latest


### PR DESCRIPTION
Fixes an issue where the version command was not reporting the same version information as shown in the startup log. The version variables were not being consistently set across different packages during builds.

## Changes
1. Standardized version variables in version.go to match main.go:
   - Changed from uppercase (Version, Commit, Date) to lowercase (version, commit, date)
   - Updated all references to use the lowercase names
2. Updated build configurations to set version variables for both packages:
   - goreleaser.yml: Added ldflags for version package
   - Makefile: Added version info from git and ldflags for both packages
   - Dockerfile: Updated ldflags to set version in both packages
   - ci.Dockerfile: Updated ldflags to set version in both packages

## Impact
- The version command now shows the same version information as the startup log
- Version information is consistent across all build methods (goreleaser, make, docker, CI)
- No changes to existing functionality, only fixes version reporting