### PR TITLE
refactor(buildinfo): centralize build info handling

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,12 +34,9 @@ builds:
     binary: dashbrr
     ldflags:
       - -s -w
-      - -X main.version={{.Version}}
-      - -X main.commit={{.Commit}}
-      - -X main.date={{.Date}}
-      - -X github.com/autobrr/dashbrr/internal/commands/version.version={{.Version}}
-      - -X github.com/autobrr/dashbrr/internal/commands/version.commit={{.Commit}}
-      - -X github.com/autobrr/dashbrr/internal/commands/version.date={{.Date}}
+      - -X github.com/autobrr/dashbrr/internal/buildinfo.Version={{.Version}}
+      - -X github.com/autobrr/dashbrr/internal/buildinfo.Commit={{.Commit}}
+      - -X github.com/autobrr/dashbrr/internal/buildinfo.Date={{.Date}}
 
 archives:
   - id: dashbrr

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,12 +33,9 @@ COPY --from=web-builder /app/web/dist ./web/dist
 
 # Build with embedded assets
 RUN go build -ldflags "-s -w \
-    -X main.version=${VERSION} \
-    -X main.commit=${REVISION} \
-    -X main.date=${BUILDTIME} \
-    -X github.com/autobrr/dashbrr/internal/commands/version.version=${VERSION} \
-    -X github.com/autobrr/dashbrr/internal/commands/version.commit=${REVISION} \
-    -X github.com/autobrr/dashbrr/internal/commands/version.date=${BUILDTIME}" \
+    -X github.com/autobrr/dashbrr/internal/buildinfo.Version=${VERSION} \
+    -X github.com/autobrr/dashbrr/internal/buildinfo.Commit=${REVISION} \
+    -X github.com/autobrr/dashbrr/internal/buildinfo.Date=${BUILDTIME}" \
     -o /app/dashbrr cmd/dashbrr/main.go
 
 # build runner

--- a/Makefile
+++ b/Makefile
@@ -27,12 +27,9 @@ BUILD_DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 # Build flags
 LDFLAGS=-s -w \
-	-X main.version=$(VERSION) \
-	-X main.commit=$(COMMIT) \
-	-X main.date=$(BUILD_DATE) \
-	-X github.com/autobrr/dashbrr/internal/commands/version.version=$(VERSION) \
-	-X github.com/autobrr/dashbrr/internal/commands/version.commit=$(COMMIT) \
-	-X github.com/autobrr/dashbrr/internal/commands/version.date=$(BUILD_DATE)
+	-X github.com/autobrr/dashbrr/internal/buildinfo.Version=$(VERSION) \
+	-X github.com/autobrr/dashbrr/internal/buildinfo.Commit=$(COMMIT) \
+	-X github.com/autobrr/dashbrr/internal/buildinfo.Date=$(BUILD_DATE)
 
 .PHONY: all clean frontend backend deps-go deps-frontend dev dev-memory docker-dev docker-dev-redis docker-dev-quick docker-build help redis-dev redis-stop docker-clean test-integration test-integration-db test-integration-db-stop run lint type-check preview
 

--- a/ci.Dockerfile
+++ b/ci.Dockerfile
@@ -40,12 +40,9 @@ RUN --network=none --mount=target=. \
     [[ "$GOARCH" == "arm" ]] && [[ "$TARGETVARIANT" == "v7" ]] && export GOARM=7; \
     echo $GOARCH $GOOS $GOARM$GOAMD64; \
     go build -ldflags "-s -w \
-    -X main.version=${VERSION} \
-    -X main.commit=${REVISION} \
-    -X main.date=${BUILDTIME} \
-    -X github.com/autobrr/dashbrr/internal/commands/version.version=${VERSION} \
-    -X github.com/autobrr/dashbrr/internal/commands/version.commit=${REVISION} \
-    -X github.com/autobrr/dashbrr/internal/commands/version.date=${BUILDTIME}" \
+    -X github.com/autobrr/dashbrr/internal/buildinfo.Version=${VERSION} \
+    -X github.com/autobrr/dashbrr/internal/buildinfo.Commit=${REVISION} \
+    -X github.com/autobrr/dashbrr/internal/buildinfo.Date=${BUILDTIME}" \
     -o /out/bin/dashbrr cmd/dashbrr/main.go
 
 # build runner

--- a/cmd/dashbrr/main.go
+++ b/cmd/dashbrr/main.go
@@ -20,18 +20,13 @@ import (
 
 	"github.com/autobrr/dashbrr/internal/api/middleware"
 	"github.com/autobrr/dashbrr/internal/api/routes"
+	"github.com/autobrr/dashbrr/internal/buildinfo"
 	"github.com/autobrr/dashbrr/internal/commands/executor"
 	"github.com/autobrr/dashbrr/internal/config"
 	"github.com/autobrr/dashbrr/internal/database"
 	"github.com/autobrr/dashbrr/internal/logger"
 	"github.com/autobrr/dashbrr/internal/services"
 	"github.com/autobrr/dashbrr/web"
-)
-
-var (
-	version = "dev"
-	commit  = ""
-	date    = ""
 )
 
 func init() {
@@ -52,9 +47,9 @@ func main() {
 
 func startServer() {
 	log.Info().
-		Str("version", version).
-		Str("commit", commit).
-		Str("build_date", date).
+		Str("version", buildinfo.Version).
+		Str("commit", buildinfo.Commit).
+		Str("build_date", buildinfo.Date).
 		Msg("Starting dashbrr")
 
 	// Check environment variable first, then fall back to flag

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -1,0 +1,20 @@
+package buildinfo
+
+import (
+	"fmt"
+	"net/http"
+	"runtime"
+)
+
+var (
+	Version = "dev"
+	Commit  = ""
+	Date    = ""
+)
+
+// AttachUserAgentHeader attaches a User-Agent header to the request
+func AttachUserAgentHeader(req *http.Request) {
+	agent := fmt.Sprintf("dashbrr/%s (%s %s)", Version, runtime.GOOS, runtime.GOARCH)
+
+	req.Header.Set("User-Agent", agent)
+}

--- a/internal/commands/version/version.go
+++ b/internal/commands/version/version.go
@@ -9,16 +9,11 @@ import (
 	"os"
 	"time"
 
+	"github.com/autobrr/dashbrr/internal/buildinfo"
 	"github.com/autobrr/dashbrr/internal/commands/base"
 )
 
-var (
-	version = "dev"
-	commit  = ""
-	date    = ""
-
-	githubAPIURL = "https://api.github.com/repos/autobrr/dashbrr/releases/latest"
-)
+const githubAPIURL = "https://api.github.com/repos/autobrr/dashbrr/releases/latest"
 
 type VersionInfo struct {
 	Version string `json:"version"`
@@ -62,9 +57,9 @@ func (c *VersionCommand) Execute(ctx context.Context, args []string) error {
 
 	// Get current version info
 	current := VersionInfo{
-		Version: version,
-		Commit:  commit,
-		Date:    date,
+		Version: buildinfo.Version,
+		Commit:  buildinfo.Commit,
+		Date:    buildinfo.Date,
 	}
 
 	if c.jsonOutput {
@@ -104,7 +99,7 @@ func (c *VersionCommand) getLatestRelease(ctx context.Context) (*GitHubRelease, 
 	}
 
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
-	req.Header.Set("User-Agent", "dashbrr/"+version)
+	buildinfo.AttachUserAgentHeader(req)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/internal/services/core/service.go
+++ b/internal/services/core/service.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 
+	"github.com/autobrr/dashbrr/internal/buildinfo"
 	"github.com/autobrr/dashbrr/internal/models"
 	"github.com/autobrr/dashbrr/internal/services/cache"
 )
@@ -128,7 +129,7 @@ func (s *ServiceCore) MakeRequestWithContext(ctx context.Context, url string, ap
 	}
 
 	// Set default headers
-	req.Header.Set("User-Agent", "dashbrr/1.0")
+	buildinfo.AttachUserAgentHeader(req)
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Connection", "keep-alive")
 


### PR DESCRIPTION
- Moves build information (version, commit, date) into a dedicated `buildinfo` package
- Updates references to build info across the codebase
- Removes duplicate definitions of build info
- Adds function to attach build info to User-Agent header