### PR TITLE
fix(cache): prevent Redis client connection leaks

### DIFF
--- a/internal/services/cache/cache.go
+++ b/internal/services/cache/cache.go
@@ -26,7 +26,7 @@ const (
 	PrefixHealth   = "health:"
 	PrefixVersion  = "version:"
 	PrefixRate     = "rate:"
-	DefaultTimeout = 5 * time.Second
+	DefaultTimeout = 30 * time.Second
 	RetryAttempts  = 2
 	RetryDelay     = 50 * time.Millisecond
 
@@ -59,71 +59,6 @@ type LocalCache struct {
 type localCacheItem struct {
 	value      []byte
 	expiration time.Time
-}
-
-// NewCache creates a new Redis cache instance with optimized configuration
-func NewCache(ctx context.Context, addr string) (Store, error) {
-	// Create a child context that can be cancelled independently
-	ctx, cancel := context.WithCancel(ctx)
-
-	// Development-optimized Redis configuration
-	client := redis.NewClient(&redis.Options{
-		Addr:            addr,
-		PoolSize:        10,
-		MinIdleConns:    2,
-		MaxConnAge:      5 * time.Minute,
-		ReadTimeout:     DefaultTimeout,
-		WriteTimeout:    DefaultTimeout,
-		PoolTimeout:     DefaultTimeout * 2,
-		IdleTimeout:     time.Minute,
-		MaxRetries:      RetryAttempts,
-		MinRetryBackoff: RetryDelay,
-		MaxRetryBackoff: time.Second,
-	})
-
-	// Test connection with simple retry
-	var lastErr error
-	for i := 0; i < RetryAttempts; i++ {
-		ctxTimeout, cancelTimeout := context.WithTimeout(ctx, DefaultTimeout)
-		err := client.Ping(ctxTimeout).Err()
-		cancelTimeout()
-
-		if err == nil {
-			lastErr = nil
-			break
-		}
-
-		lastErr = err
-		if i < RetryAttempts-1 {
-			time.Sleep(RetryDelay)
-		}
-	}
-
-	if lastErr != nil {
-		cancel() // Clean up context if connection fails
-		if client != nil {
-			client.Close()
-		}
-		return nil, lastErr
-	}
-
-	store := &RedisStore{
-		client: client,
-		local: &LocalCache{
-			items: make(map[string]*localCacheItem),
-		},
-		ctx:    ctx,
-		cancel: cancel,
-	}
-
-	// Start cleanup goroutine
-	store.wg.Add(1)
-	go func() {
-		defer store.wg.Done()
-		store.localCacheCleanup()
-	}()
-
-	return store, nil
 }
 
 // Get retrieves a value from cache with local cache first
@@ -241,54 +176,6 @@ func (s *RedisStore) Set(ctx context.Context, key string, value interface{}, exp
 	return lastErr
 }
 
-// Local cache methods
-func (s *RedisStore) getFromLocalCache(key string) ([]byte, bool) {
-	s.local.RLock()
-	defer s.local.RUnlock()
-
-	if item, exists := s.local.items[key]; exists {
-		if time.Now().Before(item.expiration) {
-			return item.value, true
-		}
-		delete(s.local.items, key)
-	}
-	return nil, false
-}
-
-func (s *RedisStore) setInLocalCache(key string, value []byte, ttl time.Duration) {
-	s.local.Lock()
-	defer s.local.Unlock()
-
-	s.local.items[key] = &localCacheItem{
-		value:      value,
-		expiration: time.Now().Add(ttl),
-	}
-}
-
-func (s *RedisStore) localCacheCleanup() {
-	ticker := time.NewTicker(CleanupInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			func() {
-				s.local.Lock()
-				defer s.local.Unlock()
-
-				now := time.Now()
-				for key, item := range s.local.items {
-					if now.After(item.expiration) {
-						delete(s.local.items, key)
-					}
-				}
-			}()
-		case <-s.ctx.Done():
-			return
-		}
-	}
-}
-
 // Delete removes a value from both Redis and local cache
 func (s *RedisStore) Delete(ctx context.Context, key string) error {
 	s.mu.RLock()
@@ -378,7 +265,6 @@ func (s *RedisStore) CleanAndCount(ctx context.Context, key string, windowStart 
 			return ctx.Err()
 		default:
 			timeoutCtx, cancel := context.WithTimeout(ctx, DefaultTimeout)
-			// Remove all entries strictly less than windowStart
 			err := s.client.ZRemRangeByScore(timeoutCtx, key, "-inf", "("+strconv.FormatInt(windowStart, 10)).Err()
 			cancel()
 
@@ -461,6 +347,54 @@ func (s *RedisStore) Expire(ctx context.Context, key string, expiration time.Dur
 	return lastErr
 }
 
+// Local cache methods
+func (s *RedisStore) getFromLocalCache(key string) ([]byte, bool) {
+	s.local.RLock()
+	defer s.local.RUnlock()
+
+	if item, exists := s.local.items[key]; exists {
+		if time.Now().Before(item.expiration) {
+			return item.value, true
+		}
+		delete(s.local.items, key)
+	}
+	return nil, false
+}
+
+func (s *RedisStore) setInLocalCache(key string, value []byte, ttl time.Duration) {
+	s.local.Lock()
+	defer s.local.Unlock()
+
+	s.local.items[key] = &localCacheItem{
+		value:      value,
+		expiration: time.Now().Add(ttl),
+	}
+}
+
+func (s *RedisStore) localCacheCleanup() {
+	ticker := time.NewTicker(CleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			func() {
+				s.local.Lock()
+				defer s.local.Unlock()
+
+				now := time.Now()
+				for key, item := range s.local.items {
+					if now.After(item.expiration) {
+						delete(s.local.items, key)
+					}
+				}
+			}()
+		case <-s.ctx.Done():
+			return
+		}
+	}
+}
+
 // Close closes the Redis connection and stops the cleanup goroutine
 func (s *RedisStore) Close() error {
 	s.mu.Lock()
@@ -472,7 +406,9 @@ func (s *RedisStore) Close() error {
 	s.mu.Unlock()
 
 	// Cancel context to stop cleanup goroutine
-	s.cancel()
+	if s.cancel != nil {
+		s.cancel()
+	}
 
 	// Wait for cleanup goroutine to finish
 	s.wg.Wait()
@@ -484,6 +420,9 @@ func (s *RedisStore) Close() error {
 		s.local.items = make(map[string]*localCacheItem)
 	}()
 
-	// Close client
-	return s.client.Close()
+	// Close Redis client
+	if s.client != nil {
+		return s.client.Close()
+	}
+	return nil
 }

--- a/internal/services/cache/cache_test.go
+++ b/internal/services/cache/cache_test.go
@@ -5,9 +5,12 @@ package cache
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/go-redis/redis/v8"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,68 +20,117 @@ type testStruct struct {
 	Value int
 }
 
-func setupTestCache(t *testing.T) *RedisStore {
-	store, err := NewCache(context.Background(), "localhost:6379")
-	if err != nil {
-		t.Skip("Redis not available, skipping test:", err)
-	}
-	// Type assertion since we know it's a RedisStore
-	redisStore, ok := store.(*RedisStore)
-	if !ok {
-		t.Fatal("Expected RedisStore type")
-	}
-	return redisStore
+func setupTestDir(t *testing.T) string {
+	dir := filepath.Join(os.TempDir(), "dashbrr-test-"+time.Now().Format("20060102150405"))
+	err := os.MkdirAll(dir, 0755)
+	require.NoError(t, err, "Failed to create test directory")
+	return dir
 }
 
-func cleanupTestCache(t *testing.T, cache *RedisStore) {
-	if err := cache.Close(); err != nil {
-		t.Errorf("Failed to close cache: %v", err)
-	}
+// checkRedisAvailable checks if Redis is available at the given address
+func checkRedisAvailable(addr string) bool {
+	client := redis.NewClient(&redis.Options{
+		Addr: addr,
+	})
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	err := client.Ping(ctx).Err()
+	return err == nil
 }
 
-func TestNewCache(t *testing.T) {
+func setupTestCache(t *testing.T) Store {
+	dataDir := setupTestDir(t)
+	cfg := Config{
+		RedisAddr: "localhost:6379",
+		DataDir:   dataDir,
+	}
+
+	// Check if Redis is available
+	if !checkRedisAvailable(cfg.RedisAddr) {
+		t.Skip("Redis not available, skipping test")
+	}
+
+	store, err := InitCache(context.Background(), cfg)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		if err := store.Close(); err != nil {
+			t.Errorf("Failed to close cache: %v", err)
+		}
+		if err := os.RemoveAll(dataDir); err != nil {
+			t.Errorf("Failed to cleanup test directory: %v", err)
+		}
+	})
+
+	return store
+}
+
+func TestInitCache(t *testing.T) {
 	tests := []struct {
-		name    string
-		addr    string
-		wantErr bool
+		name      string
+		config    Config
+		wantRedis bool // true if we expect a RedisStore, false for MemoryStore
 	}{
 		{
-			name:    "Valid address",
-			addr:    "localhost:6379",
-			wantErr: false,
+			name: "Valid Redis address",
+			config: Config{
+				RedisAddr: "localhost:6379",
+				DataDir:   setupTestDir(t),
+			},
+			wantRedis: true,
 		},
 		{
-			name:    "Invalid address",
-			addr:    "invalid:6379",
-			wantErr: true,
+			name: "Invalid Redis address",
+			config: Config{
+				RedisAddr: "invalid:6379",
+				DataDir:   setupTestDir(t),
+			},
+			wantRedis: false,
+		},
+		{
+			name: "No Redis configured",
+			config: Config{
+				DataDir: setupTestDir(t),
+			},
+			wantRedis: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			store, err := NewCache(context.Background(), tt.addr)
-			if tt.wantErr {
-				assert.Error(t, err)
-				assert.Nil(t, store)
-			} else if err != nil {
-				t.Skip("Redis not available, skipping test:", err)
-			} else {
-				assert.NoError(t, err)
-				assert.NotNil(t, store)
-				// Type assertion since we know it's a RedisStore
-				cache, ok := store.(*RedisStore)
-				if !ok {
-					t.Fatal("Expected RedisStore type")
-				}
-				cleanupTestCache(t, cache)
+			if tt.wantRedis && !checkRedisAvailable(tt.config.RedisAddr) {
+				t.Skip("Redis not available, skipping test")
 			}
+
+			store, err := InitCache(context.Background(), tt.config)
+			require.NotNil(t, store, "Store should never be nil")
+
+			if tt.wantRedis {
+				redisStore, ok := store.(*RedisStore)
+				assert.True(t, ok, "Expected RedisStore type")
+				if ok {
+					err = redisStore.Close()
+					assert.NoError(t, err)
+				}
+			} else {
+				_, ok := store.(*MemoryStore)
+				assert.True(t, ok, "Expected MemoryStore type")
+				err = store.Close()
+				assert.NoError(t, err)
+			}
+
+			// Clean up test directory
+			err = os.RemoveAll(tt.config.DataDir)
+			assert.NoError(t, err)
 		})
 	}
 }
 
 func TestBasicOperations(t *testing.T) {
 	cache := setupTestCache(t)
-	defer cleanupTestCache(t, cache)
 
 	ctx := context.Background()
 	tests := []struct {
@@ -140,7 +192,6 @@ func TestBasicOperations(t *testing.T) {
 
 func TestLocalCache(t *testing.T) {
 	cache := setupTestCache(t)
-	defer cleanupTestCache(t, cache)
 
 	ctx := context.Background()
 	tests := []struct {
@@ -169,11 +220,6 @@ func TestLocalCache(t *testing.T) {
 			err := cache.Set(ctx, tt.key, tt.value, tt.ttl)
 			require.NoError(t, err)
 
-			// Check local cache
-			data, exists := cache.getFromLocalCache(tt.key)
-			assert.True(t, exists)
-			assert.NotEmpty(t, data)
-
 			// Get value should use local cache
 			var retrieved testStruct
 			err = cache.Get(ctx, tt.key, &retrieved)
@@ -183,8 +229,8 @@ func TestLocalCache(t *testing.T) {
 			if tt.ttl == time.Second {
 				// Wait for short TTL to expire
 				time.Sleep(time.Second * 2)
-				_, exists = cache.getFromLocalCache(tt.key)
-				assert.False(t, exists, "Cache entry should have expired")
+				err = cache.Get(ctx, tt.key, &retrieved)
+				assert.Equal(t, ErrKeyNotFound, err, "Cache entry should have expired")
 			}
 		})
 	}
@@ -192,7 +238,6 @@ func TestLocalCache(t *testing.T) {
 
 func TestRateLimitOperations(t *testing.T) {
 	cache := setupTestCache(t)
-	defer cleanupTestCache(t, cache)
 
 	ctx := context.Background()
 	key := "test:rate:limit"
@@ -241,7 +286,6 @@ func TestRateLimitOperations(t *testing.T) {
 
 func TestConcurrentAccess(t *testing.T) {
 	cache := setupTestCache(t)
-	defer cleanupTestCache(t, cache)
 
 	ctx := context.Background()
 	key := "test:concurrent"
@@ -282,7 +326,6 @@ func TestConcurrentAccess(t *testing.T) {
 
 func TestCleanup(t *testing.T) {
 	cache := setupTestCache(t)
-	defer cleanupTestCache(t, cache)
 
 	ctx := context.Background()
 	key := "test:cleanup"
@@ -293,30 +336,20 @@ func TestCleanup(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify initial set
-	_, exists := cache.getFromLocalCache(key)
-	assert.True(t, exists)
+	var retrieved testStruct
+	err = cache.Get(ctx, key, &retrieved)
+	require.NoError(t, err)
 
 	// Wait for cleanup
 	time.Sleep(time.Second * 2)
 
-	// Trigger cleanup manually
-	cache.local.Lock()
-	now := time.Now()
-	for k, item := range cache.local.items {
-		if now.After(item.expiration) {
-			delete(cache.local.items, k)
-		}
-	}
-	cache.local.Unlock()
-
 	// Verify cleanup
-	_, exists = cache.getFromLocalCache(key)
-	assert.False(t, exists, "Cache entry should have been cleaned up")
+	err = cache.Get(ctx, key, &retrieved)
+	assert.Equal(t, ErrKeyNotFound, err, "Cache entry should have been cleaned up")
 }
 
 func TestContextCancellation(t *testing.T) {
 	cache := setupTestCache(t)
-	defer cleanupTestCache(t, cache)
 
 	// Create a cancelled context
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
* Consolidate Redis client creation to single point in InitCache
* Ensure proper cleanup of Redis clients on initialization failure
* Improve Close() method to properly clean up all resources
* Add better synchronization and error handling
* Update tests to use new initialization pattern

Fixes issue with "max number of clients reached" errors by properly managing Redis client lifecycle. Each cache store now creates only one client and ensures proper cleanup in all scenarios.