### PR TITLE
fix(auth): replace hardcoded OAuth endpoints with OIDC Discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Required OIDC environment variables:
 OIDC_ISSUER=https://your-provider.com
 OIDC_CLIENT_ID=your-client-id
 OIDC_CLIENT_SECRET=your-client-secret
-OIDC_REDIRECT_URL=http://localhost:3000/auth/callback
+OIDC_REDIRECT_URL=http://localhost:3000/api/auth/callback
 ```
 
 ## Tech Stack

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -99,5 +99,5 @@
 
 - `OIDC_REDIRECT_URL`
   - Purpose: Callback URL for OIDC authentication
-  - Example: `http://localhost:3000/auth/callback`
+  - Example: `http://localhost:3000/api/auth/callback`
   - Required if using OIDC

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -42,25 +42,18 @@ func NewAuthHandler(config *types.AuthConfig, store cache.Store) *AuthHandler {
 		Str("issuer", config.Issuer).
 		Msg("initializing auth handler")
 
-	// Try discovery first
+	// Get provider endpoints through OIDC discovery
 	endpoints, userinfoURL, err := getProviderEndpoints(ctx, httpClient, config.Issuer)
 	if err != nil {
-		// Fall back to default endpoints
-		endpoints = oauth2.Endpoint{
-			AuthURL:  config.Issuer + "/authorize",
-			TokenURL: config.Issuer + "/oauth/token",
-		}
-		log.Debug().
-			Err(err).
-			Str("auth_url", endpoints.AuthURL).
-			Str("token_url", endpoints.TokenURL).
-			Msg("discovery failed, using default endpoints")
-	} else {
-		log.Debug().
-			Str("auth_url", endpoints.AuthURL).
-			Str("token_url", endpoints.TokenURL).
-			Msg("using discovered endpoints")
+		log.Error().Err(err).
+			Msg("OIDC discovery failed. Please ensure your provider supports OpenID Connect discovery as specified in https://openid.net/specs/openid-connect-discovery-1_0.html")
+		return nil
 	}
+
+	log.Debug().
+		Str("auth_url", endpoints.AuthURL).
+		Str("token_url", endpoints.TokenURL).
+		Msg("using discovered endpoints")
 
 	oauth2Config := &oauth2.Config{
 		ClientID:     config.ClientID,

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -9,7 +9,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -29,29 +31,123 @@ type AuthHandler struct {
 }
 
 func NewAuthHandler(config *types.AuthConfig, store cache.Store) *AuthHandler {
-	// Ensure issuer URL doesn't have trailing slash
-	issuer := strings.TrimRight(config.Issuer, "/")
+	// Create HTTP client with timeout
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+
+	// Create context with timeout for provider configuration
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	log.Debug().
+		Str("issuer", config.Issuer).
+		Msg("initializing auth handler")
+
+	// Try discovery first
+	provider, err := getProviderEndpoints(ctx, httpClient, config.Issuer)
+	if err != nil {
+		// Fall back to default endpoints
+		provider = oauth2.Endpoint{
+			AuthURL:  config.Issuer + "/authorize",
+			TokenURL: config.Issuer + "/oauth/token",
+		}
+		log.Debug().
+			Err(err).
+			Str("auth_url", provider.AuthURL).
+			Str("token_url", provider.TokenURL).
+			Msg("discovery failed, using default endpoints")
+	} else {
+		log.Debug().
+			Str("auth_url", provider.AuthURL).
+			Str("token_url", provider.TokenURL).
+			Msg("using discovered endpoints")
+	}
 
 	oauth2Config := &oauth2.Config{
 		ClientID:     config.ClientID,
 		ClientSecret: config.ClientSecret,
 		RedirectURL:  config.RedirectURL,
-		Endpoint: oauth2.Endpoint{
-			AuthURL:  fmt.Sprintf("%s/authorize", issuer),
-			TokenURL: fmt.Sprintf("%s/oauth/token", issuer),
-		},
-		Scopes: []string{"openid", "profile", "email"},
+		Endpoint:     provider,
+		Scopes:       []string{"openid", "profile", "email"},
 	}
 
 	return &AuthHandler{
 		config:       config,
 		cache:        store,
 		oauth2Config: oauth2Config,
-		httpClient:   &http.Client{Timeout: 10 * time.Second},
+		httpClient:   httpClient,
 	}
 }
 
-// generateSecureRandomString generates a cryptographically secure random string
+// getProviderEndpoints fetches provider configuration and returns oauth2.Endpoint
+// Examples:
+// Simple issuer (Google):
+//   Input:  https://accounts.google.com
+//   Result: https://accounts.google.com/.well-known/openid-configuration
+//
+// Path-based (e.g. Keycloak realm):
+//   Input:  https://auth.example.com/realms/myrealm
+//   Result: https://auth.example.com/realms/myrealm/.well-known/openid-configuration
+func getProviderEndpoints(ctx context.Context, client *http.Client, issuer string) (oauth2.Endpoint, error) {
+
+	issuer = strings.TrimRight(issuer, "/")
+
+	// Construct well-known URL according to spec
+	var wellKnown string
+	u, err := url.Parse(issuer)
+	if err != nil {
+		return oauth2.Endpoint{}, fmt.Errorf("invalid issuer URL: %w", err)
+	}
+
+	if u.Path == "" || u.Path == "/" {
+		// No path component: /.well-known/openid-configuration
+		wellKnown = issuer + "/.well-known/openid-configuration"
+	} else {
+		// Has path component: /path/.well-known/openid-configuration
+		base := strings.TrimRight(u.Path, "/")
+		u.Path = base + "/.well-known/openid-configuration"
+		wellKnown = u.String()
+	}
+
+	log.Debug().
+		Str("issuer", issuer).
+		Str("well_known_url", wellKnown).
+		Msg("attempting to fetch provider configuration")
+
+	req, err := http.NewRequestWithContext(ctx, "GET", wellKnown, nil)
+	if err != nil {
+		return oauth2.Endpoint{}, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return oauth2.Endpoint{}, fmt.Errorf("failed to fetch provider config: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return oauth2.Endpoint{}, fmt.Errorf("discovery request failed: %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	var config struct {
+		AuthURL  string `json:"authorization_endpoint"`
+		TokenURL string `json:"token_endpoint"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&config); err != nil {
+		return oauth2.Endpoint{}, fmt.Errorf("failed to decode provider config: %w", err)
+	}
+
+	if config.AuthURL == "" || config.TokenURL == "" {
+		return oauth2.Endpoint{}, fmt.Errorf("provider config missing required endpoints: auth_url=%s, token_url=%s", config.AuthURL, config.TokenURL)
+	}
+
+	return oauth2.Endpoint{
+		AuthURL:  config.AuthURL,
+		TokenURL: config.TokenURL,
+	}, nil
+}
+
 func generateSecureRandomString(length int) (string, error) {
 	bytes := make([]byte, length)
 	if _, err := rand.Read(bytes); err != nil {
@@ -60,7 +156,6 @@ func generateSecureRandomString(length int) (string, error) {
 	return base64.URLEncoding.EncodeToString(bytes)[:length], nil
 }
 
-// Login initiates the OIDC authentication flow
 func (h *AuthHandler) Login(c *gin.Context) {
 	// Create context with timeout for login flow
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
@@ -130,7 +225,6 @@ func (h *AuthHandler) Login(c *gin.Context) {
 	c.Redirect(http.StatusTemporaryRedirect, authURL)
 }
 
-// Callback handles the OIDC provider callback
 func (h *AuthHandler) Callback(c *gin.Context) {
 	// Create context with timeout for callback handling
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
@@ -169,8 +263,10 @@ func (h *AuthHandler) Callback(c *gin.Context) {
 		return
 	}
 
-	if err := h.cache.Delete(ctx, stateKey); err != nil && err != cache.ErrKeyNotFound {
-		log.Error().Err(err).Msg("failed to delete state from cache")
+	if err := h.cache.Delete(ctx, stateKey); err != nil {
+		if err != cache.ErrKeyNotFound {
+			log.Error().Err(err).Msg("failed to delete state from cache")
+		}
 	}
 
 	// Exchange code for token using context
@@ -233,7 +329,6 @@ func (h *AuthHandler) Callback(c *gin.Context) {
 	))
 }
 
-// Logout handles user logout
 func (h *AuthHandler) Logout(c *gin.Context) {
 	// Create context with timeout for logout
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
@@ -285,7 +380,6 @@ func (h *AuthHandler) Logout(c *gin.Context) {
 	c.Redirect(http.StatusTemporaryRedirect, logoutURL)
 }
 
-// VerifyToken verifies a JWT token
 func (h *AuthHandler) VerifyToken(c *gin.Context) {
 	// Create context with timeout for token verification
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
@@ -320,7 +414,6 @@ func (h *AuthHandler) VerifyToken(c *gin.Context) {
 	})
 }
 
-// RefreshToken handles token refresh
 func (h *AuthHandler) RefreshToken(c *gin.Context) {
 	// Create context with timeout for token refresh
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
@@ -411,7 +504,6 @@ func (h *AuthHandler) RefreshToken(c *gin.Context) {
 	})
 }
 
-// UserInfo returns the current user's information
 func (h *AuthHandler) UserInfo(c *gin.Context) {
 	// Create context with timeout for userinfo request
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -6,12 +6,11 @@ package handlers
 import (
 	"context"
 	"crypto/rand"
-	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
@@ -28,6 +27,7 @@ type AuthHandler struct {
 	cache        cache.Store
 	oauth2Config *oauth2.Config
 	httpClient   *http.Client
+	userinfoURL  string
 }
 
 func NewAuthHandler(config *types.AuthConfig, store cache.Store) *AuthHandler {
@@ -43,22 +43,22 @@ func NewAuthHandler(config *types.AuthConfig, store cache.Store) *AuthHandler {
 		Msg("initializing auth handler")
 
 	// Try discovery first
-	provider, err := getProviderEndpoints(ctx, httpClient, config.Issuer)
+	endpoints, userinfoURL, err := getProviderEndpoints(ctx, httpClient, config.Issuer)
 	if err != nil {
 		// Fall back to default endpoints
-		provider = oauth2.Endpoint{
+		endpoints = oauth2.Endpoint{
 			AuthURL:  config.Issuer + "/authorize",
 			TokenURL: config.Issuer + "/oauth/token",
 		}
 		log.Debug().
 			Err(err).
-			Str("auth_url", provider.AuthURL).
-			Str("token_url", provider.TokenURL).
+			Str("auth_url", endpoints.AuthURL).
+			Str("token_url", endpoints.TokenURL).
 			Msg("discovery failed, using default endpoints")
 	} else {
 		log.Debug().
-			Str("auth_url", provider.AuthURL).
-			Str("token_url", provider.TokenURL).
+			Str("auth_url", endpoints.AuthURL).
+			Str("token_url", endpoints.TokenURL).
 			Msg("using discovered endpoints")
 	}
 
@@ -66,7 +66,7 @@ func NewAuthHandler(config *types.AuthConfig, store cache.Store) *AuthHandler {
 		ClientID:     config.ClientID,
 		ClientSecret: config.ClientSecret,
 		RedirectURL:  config.RedirectURL,
-		Endpoint:     provider,
+		Endpoint:     endpoints,
 		Scopes:       []string{"openid", "profile", "email"},
 	}
 
@@ -75,77 +75,74 @@ func NewAuthHandler(config *types.AuthConfig, store cache.Store) *AuthHandler {
 		cache:        store,
 		oauth2Config: oauth2Config,
 		httpClient:   httpClient,
+		userinfoURL:  userinfoURL,
 	}
+}
+
+type providerConfig struct {
+	Issuer                string `json:"issuer"`
+	AuthorizationEndpoint string `json:"authorization_endpoint"`
+	TokenEndpoint         string `json:"token_endpoint"`
+	UserinfoEndpoint      string `json:"userinfo_endpoint"`
 }
 
 // getProviderEndpoints fetches provider configuration and returns oauth2.Endpoint
 // Examples:
 // Simple issuer (Google):
-//   Input:  https://accounts.google.com
-//   Result: https://accounts.google.com/.well-known/openid-configuration
+//
+//	Input:  https://accounts.google.com
+//	Result: https://accounts.google.com/.well-known/openid-configuration
 //
 // Path-based (e.g. Keycloak realm):
-//   Input:  https://auth.example.com/realms/myrealm
-//   Result: https://auth.example.com/realms/myrealm/.well-known/openid-configuration
-func getProviderEndpoints(ctx context.Context, client *http.Client, issuer string) (oauth2.Endpoint, error) {
-
+//
+//	Input:  https://auth.example.com/realms/myrealm
+//	Result: https://auth.example.com/realms/myrealm/.well-known/openid-configuration
+func getProviderEndpoints(ctx context.Context, client *http.Client, issuer string) (oauth2.Endpoint, string, error) {
 	issuer = strings.TrimRight(issuer, "/")
 
 	// Construct well-known URL according to spec
 	var wellKnown string
-	u, err := url.Parse(issuer)
-	if err != nil {
-		return oauth2.Endpoint{}, fmt.Errorf("invalid issuer URL: %w", err)
+	if strings.Contains(issuer, "/.well-known/openid-configuration") {
+		wellKnown = issuer
+	} else {
+		wellKnown = issuer + "/.well-known/openid-configuration"
 	}
 
-	if u.Path == "" || u.Path == "/" {
-		// No path component: /.well-known/openid-configuration
-		wellKnown = issuer + "/.well-known/openid-configuration"
-	} else {
-		// Has path component: /path/.well-known/openid-configuration
-		base := strings.TrimRight(u.Path, "/")
-		u.Path = base + "/.well-known/openid-configuration"
-		wellKnown = u.String()
+	req, err := http.NewRequestWithContext(ctx, "GET", wellKnown, nil)
+	if err != nil {
+		return oauth2.Endpoint{}, "", fmt.Errorf("creating discovery request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return oauth2.Endpoint{}, "", fmt.Errorf("fetching discovery document: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return oauth2.Endpoint{}, "", fmt.Errorf("reading discovery document: %w", err)
 	}
 
 	log.Debug().
 		Str("issuer", issuer).
 		Str("well_known_url", wellKnown).
-		Msg("attempting to fetch provider configuration")
+		Msg("OIDC discovery successful")
 
-	req, err := http.NewRequestWithContext(ctx, "GET", wellKnown, nil)
-	if err != nil {
-		return oauth2.Endpoint{}, fmt.Errorf("failed to create request: %w", err)
+	var discovery struct {
+		AuthURL     string `json:"authorization_endpoint"`
+		TokenURL    string `json:"token_endpoint"`
+		UserinfoURL string `json:"userinfo_endpoint"`
 	}
 
-	resp, err := client.Do(req)
-	if err != nil {
-		return oauth2.Endpoint{}, fmt.Errorf("failed to fetch provider config: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return oauth2.Endpoint{}, fmt.Errorf("discovery request failed: %d, body: %s", resp.StatusCode, string(body))
-	}
-
-	var config struct {
-		AuthURL  string `json:"authorization_endpoint"`
-		TokenURL string `json:"token_endpoint"`
-	}
-
-	if err := json.NewDecoder(resp.Body).Decode(&config); err != nil {
-		return oauth2.Endpoint{}, fmt.Errorf("failed to decode provider config: %w", err)
-	}
-
-	if config.AuthURL == "" || config.TokenURL == "" {
-		return oauth2.Endpoint{}, fmt.Errorf("provider config missing required endpoints: auth_url=%s, token_url=%s", config.AuthURL, config.TokenURL)
+	if err := json.Unmarshal(body, &discovery); err != nil {
+		return oauth2.Endpoint{}, "", fmt.Errorf("parsing discovery document: %w", err)
 	}
 
 	return oauth2.Endpoint{
-		AuthURL:  config.AuthURL,
-		TokenURL: config.TokenURL,
-	}, nil
+		AuthURL:  discovery.AuthURL,
+		TokenURL: discovery.TokenURL,
+	}, discovery.UserinfoURL, nil
 }
 
 func generateSecureRandomString(length int) (string, error) {
@@ -153,7 +150,7 @@ func generateSecureRandomString(length int) (string, error) {
 	if _, err := rand.Read(bytes); err != nil {
 		return "", err
 	}
-	return base64.URLEncoding.EncodeToString(bytes)[:length], nil
+	return hex.EncodeToString(bytes)[:length], nil
 }
 
 func (h *AuthHandler) Login(c *gin.Context) {
@@ -381,16 +378,16 @@ func (h *AuthHandler) Logout(c *gin.Context) {
 }
 
 func (h *AuthHandler) VerifyToken(c *gin.Context) {
-	// Create context with timeout for token verification
-	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
-	defer cancel()
-
 	sessionID, err := c.Cookie("session")
 	if err != nil {
 		log.Trace().Msg("no session cookie found")
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "No session found"})
 		return
 	}
+
+	// Create context with timeout for token verification
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+	defer cancel()
 
 	sessionKey := fmt.Sprintf("oidc:session:%s", sessionID)
 	var sessionData types.SessionData
@@ -415,10 +412,6 @@ func (h *AuthHandler) VerifyToken(c *gin.Context) {
 }
 
 func (h *AuthHandler) RefreshToken(c *gin.Context) {
-	// Create context with timeout for token refresh
-	ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
-	defer cancel()
-
 	sessionID, err := c.Cookie("session")
 	if err != nil {
 		log.Error().Err(err).Msg("no session cookie found")
@@ -428,43 +421,35 @@ func (h *AuthHandler) RefreshToken(c *gin.Context) {
 
 	sessionKey := fmt.Sprintf("oidc:session:%s", sessionID)
 	var sessionData types.SessionData
-	if err := h.cache.Get(ctx, sessionKey, &sessionData); err != nil {
-		if ctx.Err() != nil {
-			log.Error().Err(ctx.Err()).Msg("Context canceled while getting session")
-			c.JSON(http.StatusGatewayTimeout, gin.H{"error": "Operation timed out"})
-			return
-		}
+	if err := h.cache.Get(c.Request.Context(), sessionKey, &sessionData); err != nil {
 		if err == cache.ErrKeyNotFound {
 			log.Debug().Msg("session not found or expired")
 		} else {
 			log.Error().Err(err).Msg("failed to get session from cache")
 		}
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "Session not found"})
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Session expired"})
 		return
 	}
 
 	token := &oauth2.Token{
+		AccessToken:  sessionData.AccessToken,
+		TokenType:    "Bearer",
 		RefreshToken: sessionData.RefreshToken,
 		Expiry:       sessionData.ExpiresAt,
 	}
 
 	// Create token source with context
-	tokenSource := h.oauth2Config.TokenSource(ctx, token)
+	tokenSource := h.oauth2Config.TokenSource(c.Request.Context(), token)
 
 	// Refresh the token
 	newToken, err := tokenSource.Token()
 	if err != nil {
-		if ctx.Err() != nil {
-			log.Error().Err(ctx.Err()).Msg("Context canceled during token refresh")
-			c.JSON(http.StatusGatewayTimeout, gin.H{"error": "Operation timed out"})
-			return
-		}
 		log.Error().Err(err).Msg("token refresh failed")
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to refresh token"})
 		return
 	}
 
-	// Update session with new token data
+	// Update session data with new token
 	sessionData.AccessToken = newToken.AccessToken
 	sessionData.RefreshToken = newToken.RefreshToken
 	sessionData.ExpiresAt = newToken.Expiry
@@ -473,28 +458,11 @@ func (h *AuthHandler) RefreshToken(c *gin.Context) {
 	}
 
 	// Store updated session
-	if err := h.cache.Set(ctx, sessionKey, sessionData, time.Until(newToken.Expiry)); err != nil {
-		if ctx.Err() != nil {
-			log.Error().Err(ctx.Err()).Msg("Context canceled while updating session")
-			c.JSON(http.StatusGatewayTimeout, gin.H{"error": "Operation timed out"})
-			return
-		}
+	if err := h.cache.Set(c.Request.Context(), sessionKey, sessionData, time.Until(newToken.Expiry)); err != nil {
 		log.Error().Err(err).Msg("failed to update session in cache")
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update session"})
 		return
 	}
-
-	var isSecure = c.GetHeader("X-Forwarded-Proto") == "https"
-
-	c.SetCookie(
-		"session",
-		newToken.AccessToken,
-		int(time.Until(newToken.Expiry).Seconds()),
-		"/",
-		"",
-		isSecure,
-		true,
-	)
 
 	c.JSON(http.StatusOK, gin.H{
 		"access_token":  newToken.AccessToken,
@@ -505,75 +473,22 @@ func (h *AuthHandler) RefreshToken(c *gin.Context) {
 }
 
 func (h *AuthHandler) UserInfo(c *gin.Context) {
-	// Create context with timeout for userinfo request
-	ctx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
-	defer cancel()
-
 	sessionID, err := c.Cookie("session")
 	if err != nil {
-		log.Error().Err(err).Msg("no session cookie found")
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "No session found"})
 		return
 	}
 
 	sessionKey := fmt.Sprintf("oidc:session:%s", sessionID)
 	var sessionData types.SessionData
-	if err := h.cache.Get(ctx, sessionKey, &sessionData); err != nil {
-		if ctx.Err() != nil {
-			log.Error().Err(ctx.Err()).Msg("Context canceled while getting session")
-			c.JSON(http.StatusGatewayTimeout, gin.H{"error": "Operation timed out"})
-			return
-		}
-		if err == cache.ErrKeyNotFound {
-			log.Debug().Msg("session not found or expired")
-		} else {
-			log.Error().Err(err).Msg("failed to get session from cache")
-		}
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "Session not found"})
+	if err := h.cache.Get(c.Request.Context(), sessionKey, &sessionData); err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid session"})
 		return
 	}
 
-	userinfoURL := fmt.Sprintf("%s/userinfo", strings.TrimRight(h.config.Issuer, "/"))
-	req, err := http.NewRequestWithContext(ctx, "GET", userinfoURL, nil)
-	if err != nil {
-		log.Error().Err(err).Msg("failed to create userinfo request")
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
-		return
-	}
-
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", sessionData.AccessToken))
-
-	resp, err := h.httpClient.Do(req)
-	if err != nil {
-		if ctx.Err() != nil {
-			log.Error().Err(ctx.Err()).Msg("Context canceled during userinfo request")
-			c.JSON(http.StatusGatewayTimeout, gin.H{"error": "Operation timed out"})
-			return
-		}
-		log.Error().Err(err).Msg("userinfo request failed")
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get user info"})
-		return
-	}
-
-	if resp == nil {
-		log.Error().Msg("received nil response from userinfo endpoint")
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get user info"})
-		return
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		log.Error().Int("status", resp.StatusCode).Msg("userinfo request returned non-200 status")
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get user info"})
-		return
-	}
-
-	var userInfo map[string]interface{}
-	if err := json.NewDecoder(resp.Body).Decode(&userInfo); err != nil {
-		log.Error().Err(err).Msg("failed to decode userinfo response")
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to process user info"})
-		return
-	}
-
-	c.JSON(http.StatusOK, userInfo)
+	// Just return the basic session info we already have
+	c.JSON(http.StatusOK, gin.H{
+		"user_id": sessionData.UserID,
+		"auth_type": sessionData.AuthType,
+	})
 }

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -31,11 +31,8 @@ type AuthHandler struct {
 }
 
 func NewAuthHandler(config *types.AuthConfig, store cache.Store) *AuthHandler {
-	// Create HTTP client with timeout
-	httpClient := &http.Client{Timeout: 10 * time.Second}
-
-	// Create context with timeout for provider configuration
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	httpClient := &http.Client{Timeout: 1 * time.Second}
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
 	log.Debug().
@@ -481,7 +478,7 @@ func (h *AuthHandler) UserInfo(c *gin.Context) {
 
 	// Just return the basic session info we already have
 	c.JSON(http.StatusOK, gin.H{
-		"user_id": sessionData.UserID,
+		"user_id":   sessionData.UserID,
 		"auth_type": sessionData.AuthType,
 	})
 }

--- a/internal/api/handlers/auth_test.go
+++ b/internal/api/handlers/auth_test.go
@@ -6,7 +6,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
-	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -25,111 +25,76 @@ type MockStore struct {
 	mock.Mock
 }
 
-// safeArgs ensures we always return a valid mock.Arguments
-func (m *MockStore) safeArgs(args mock.Arguments) mock.Arguments {
-	if args == nil {
-		return mock.Arguments{errors.New("mock not configured")}
-	}
-	return args
-}
-
 func (m *MockStore) Get(ctx context.Context, key string, value interface{}) error {
-	args := m.safeArgs(m.Called(ctx, key, value))
-	if args.Get(0) == nil {
-		return nil
-	}
-	if err, ok := args.Get(0).(error); ok {
-		return err
-	}
-	return errors.New("unknown error")
+	args := m.Called(ctx, key, value)
+	return args.Error(0)
 }
 
-func (m *MockStore) Set(ctx context.Context, key string, value interface{}, expiration time.Duration) error {
-	args := m.safeArgs(m.Called(ctx, key, value, expiration))
-	if args.Get(0) == nil {
-		return nil
-	}
-	if err, ok := args.Get(0).(error); ok {
-		return err
-	}
-	return errors.New("unknown error")
+func (m *MockStore) Set(ctx context.Context, key string, value interface{}, ttl time.Duration) error {
+	args := m.Called(ctx, key, value, ttl)
+	return args.Error(0)
 }
 
 func (m *MockStore) Delete(ctx context.Context, key string) error {
-	args := m.safeArgs(m.Called(ctx, key))
-	if args.Get(0) == nil {
-		return nil
-	}
-	if err, ok := args.Get(0).(error); ok {
-		return err
-	}
-	return errors.New("unknown error")
-}
-
-func (m *MockStore) Increment(ctx context.Context, key string, timestamp int64) error {
-	args := m.safeArgs(m.Called(ctx, key, timestamp))
-	if args.Get(0) == nil {
-		return nil
-	}
-	if err, ok := args.Get(0).(error); ok {
-		return err
-	}
-	return errors.New("unknown error")
-}
-
-func (m *MockStore) CleanAndCount(ctx context.Context, key string, windowStart int64) error {
-	args := m.safeArgs(m.Called(ctx, key, windowStart))
-	if args.Get(0) == nil {
-		return nil
-	}
-	if err, ok := args.Get(0).(error); ok {
-		return err
-	}
-	return errors.New("unknown error")
-}
-
-func (m *MockStore) GetCount(ctx context.Context, key string) (int64, error) {
-	args := m.safeArgs(m.Called(ctx, key))
-	var count int64
-	if args.Get(0) != nil {
-		if c, ok := args.Get(0).(int64); ok {
-			count = c
-		}
-	}
-	var err error
-	if args.Get(1) != nil {
-		if e, ok := args.Get(1).(error); ok {
-			err = e
-		}
-	}
-	return count, err
-}
-
-func (m *MockStore) Expire(ctx context.Context, key string, expiration time.Duration) error {
-	args := m.safeArgs(m.Called(ctx, key, expiration))
-	if args.Get(0) == nil {
-		return nil
-	}
-	if err, ok := args.Get(0).(error); ok {
-		return err
-	}
-	return errors.New("unknown error")
+	args := m.Called(ctx, key)
+	return args.Error(0)
 }
 
 func (m *MockStore) Close() error {
-	args := m.safeArgs(m.Called())
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockStore) Increment(ctx context.Context, key string, timestamp int64) error {
+	args := m.Called(ctx, key, timestamp)
+	return args.Error(0)
+}
+
+func (m *MockStore) CleanAndCount(ctx context.Context, key string, windowStart int64) error {
+	args := m.Called(ctx, key, windowStart)
+	return args.Error(0)
+}
+
+func (m *MockStore) GetCount(ctx context.Context, key string) (int64, error) {
+	args := m.Called(ctx, key)
 	if args.Get(0) == nil {
-		return nil
+		return 0, args.Error(1)
 	}
-	if err, ok := args.Get(0).(error); ok {
-		return err
-	}
-	return errors.New("unknown error")
+	return args.Get(0).(int64), args.Error(1)
+}
+
+func (m *MockStore) Expire(ctx context.Context, key string, expiration time.Duration) error {
+	args := m.Called(ctx, key, expiration)
+	return args.Error(0)
 }
 
 func TestNewAuthHandler(t *testing.T) {
+	var serverURL string
+
+	// Create a test server that responds to OIDC discovery
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/openid-configuration" {
+			t.Errorf("Expected request to /.well-known/openid-configuration, got %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Create discovery response with proper endpoints
+		response := fmt.Sprintf(`{
+			"issuer": "%s",
+			"authorization_endpoint": "%s/authorize",
+			"token_endpoint": "%s/oauth/token",
+			"userinfo_endpoint": "%s/userinfo"
+		}`, serverURL, serverURL, serverURL, serverURL)
+		w.Write([]byte(response))
+	}))
+	defer ts.Close()
+	serverURL = ts.URL
+
 	config := &types.AuthConfig{
-		Issuer:       "https://test.auth0.com",
+		Issuer:       serverURL,
 		ClientID:     "test-client-id",
 		ClientSecret: "test-client-secret",
 		RedirectURL:  "http://localhost:3000/callback",
@@ -144,6 +109,28 @@ func TestNewAuthHandler(t *testing.T) {
 	assert.Equal(t, "test-client-id", handler.oauth2Config.ClientID)
 	assert.Equal(t, "test-client-secret", handler.oauth2Config.ClientSecret)
 	assert.Equal(t, "http://localhost:3000/callback", handler.oauth2Config.RedirectURL)
+}
+
+func TestNewAuthHandler_DiscoveryFailed(t *testing.T) {
+	var serverURL string
+
+	// Create a test server that returns an error
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+	serverURL = ts.URL
+
+	config := &types.AuthConfig{
+		Issuer:       serverURL,
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		RedirectURL:  "http://localhost:3000/callback",
+	}
+	mockStore := new(MockStore)
+
+	handler := NewAuthHandler(config, mockStore)
+	assert.Nil(t, handler, "Handler should be nil when discovery fails")
 }
 
 func TestLogin_NoFrontendURL(t *testing.T) {

--- a/internal/api/handlers/auth_test.go
+++ b/internal/api/handlers/auth_test.go
@@ -5,6 +5,7 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -231,7 +232,7 @@ func TestGetProviderEndpoints(t *testing.T) {
 			name:       "google provider",
 			issuer:     "https://accounts.google.com",
 			mockStatus: http.StatusOK,
-			mockBody:   `{"authorization_endpoint":"https://accounts.google.com/o/oauth2/v2/auth","token_endpoint":"https://oauth2.googleapis.com/token"}`,
+			mockBody:   `{"authorization_endpoint":"https://accounts.google.com/o/oauth2/v2/auth","token_endpoint":"https://oauth2.googleapis.com/token","userinfo_endpoint":"https://openidconnect.googleapis.com/v1/userinfo"}`,
 			wantPath:   "/.well-known/openid-configuration",
 			wantErr:    false,
 		},
@@ -239,7 +240,7 @@ func TestGetProviderEndpoints(t *testing.T) {
 			name:       "keycloak provider with path",
 			issuer:     "https://auth.example.com/realms/myrealm/",
 			mockStatus: http.StatusOK,
-			mockBody:   `{"authorization_endpoint":"https://auth.example.com/realms/myrealm/protocol/openid-connect/auth","token_endpoint":"https://auth.example.com/realms/myrealm/protocol/openid-connect/token"}`,
+			mockBody:   `{"authorization_endpoint":"https://auth.example.com/realms/myrealm/protocol/openid-connect/auth","token_endpoint":"https://auth.example.com/realms/myrealm/protocol/openid-connect/token","userinfo_endpoint":"https://auth.example.com/realms/myrealm/protocol/openid-connect/userinfo"}`,
 			wantPath:   "/realms/myrealm/.well-known/openid-configuration",
 			wantErr:    false,
 		},
@@ -265,14 +266,26 @@ func TestGetProviderEndpoints(t *testing.T) {
 			testIssuer := u.String()
 
 			// Test the function
-			got, err := getProviderEndpoints(context.Background(), http.DefaultClient, testIssuer)
+			endpoint, userinfoURL, err := getProviderEndpoints(context.Background(), http.DefaultClient, testIssuer)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
 			}
 			assert.NoError(t, err)
-			assert.NotEmpty(t, got.AuthURL)
-			assert.NotEmpty(t, got.TokenURL)
+
+			// Parse mock response to get expected values
+			var config struct {
+				AuthURL     string `json:"authorization_endpoint"`
+				TokenURL    string `json:"token_endpoint"`
+				UserinfoURL string `json:"userinfo_endpoint"`
+			}
+			err = json.Unmarshal([]byte(tt.mockBody), &config)
+			assert.NoError(t, err)
+
+			// Verify endpoints match
+			assert.Equal(t, config.AuthURL, endpoint.AuthURL)
+			assert.Equal(t, config.TokenURL, endpoint.TokenURL)
+			assert.Equal(t, config.UserinfoURL, userinfoURL)
 		})
 	}
 }

--- a/internal/api/handlers/auth_test.go
+++ b/internal/api/handlers/auth_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -215,4 +216,63 @@ func TestLogout_NoFrontendURL(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	mockStore.AssertExpectations(t)
+}
+
+func TestGetProviderEndpoints(t *testing.T) {
+	tests := []struct {
+		name       string
+		issuer     string
+		mockStatus int
+		mockBody   string
+		wantPath   string
+		wantErr    bool
+	}{
+		{
+			name:       "google provider",
+			issuer:     "https://accounts.google.com",
+			mockStatus: http.StatusOK,
+			mockBody:   `{"authorization_endpoint":"https://accounts.google.com/o/oauth2/v2/auth","token_endpoint":"https://oauth2.googleapis.com/token"}`,
+			wantPath:   "/.well-known/openid-configuration",
+			wantErr:    false,
+		},
+		{
+			name:       "keycloak provider with path",
+			issuer:     "https://auth.example.com/realms/myrealm/",
+			mockStatus: http.StatusOK,
+			mockBody:   `{"authorization_endpoint":"https://auth.example.com/realms/myrealm/protocol/openid-connect/auth","token_endpoint":"https://auth.example.com/realms/myrealm/protocol/openid-connect/token"}`,
+			wantPath:   "/realms/myrealm/.well-known/openid-configuration",
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test server
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, tt.wantPath, r.URL.Path, "unexpected request path")
+				w.WriteHeader(tt.mockStatus)
+				w.Write([]byte(tt.mockBody))
+			}))
+			defer ts.Close()
+
+			// Replace the issuer host with our test server
+			u, err := url.Parse(tt.issuer)
+			assert.NoError(t, err)
+			tsURL, err := url.Parse(ts.URL)
+			assert.NoError(t, err)
+			u.Host = tsURL.Host
+			u.Scheme = tsURL.Scheme
+			testIssuer := u.String()
+
+			// Test the function
+			got, err := getProviderEndpoints(context.Background(), http.DefaultClient, testIssuer)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.NotEmpty(t, got.AuthURL)
+			assert.NotEmpty(t, got.TokenURL)
+		})
+	}
 }

--- a/web/src/components/services/TailscaleStatusBar.tsx
+++ b/web/src/components/services/TailscaleStatusBar.tsx
@@ -134,14 +134,7 @@ export const TailscaleStatusBar: React.FC<TailscaleStatusBarProps> = () => {
         setError("Not configured");
       }
     }
-  }, [
-    config?.url,
-    config?.apiKey,
-    fetchDevices,
-    isAuthenticated,
-    loading,
-    config,
-  ]);
+  }, [config?.url, config?.apiKey, fetchDevices, isAuthenticated, loading]);
 
   const handleRemoveClick = () => {
     setIsRemoveModalOpen(true);

--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -19,36 +19,6 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 // Debounce function with proper type handling
-function debounce<TArgs extends unknown[], TReturn>(
-  func: (...args: TArgs) => Promise<TReturn>,
-  waitTime: number
-): (...args: TArgs) => Promise<TReturn> {
-  let timeout: NodeJS.Timeout;
-  let lastCall = 0;
-
-  return (...args: TArgs): Promise<TReturn> => {
-    return new Promise((resolve, reject) => {
-      const now = Date.now();
-      const timeSinceLastCall = now - lastCall;
-
-      clearTimeout(timeout);
-
-      if (timeSinceLastCall >= waitTime) {
-        lastCall = now;
-        func(...args)
-          .then(resolve)
-          .catch(reject);
-      } else {
-        timeout = setTimeout(() => {
-          lastCall = Date.now();
-          func(...args)
-            .then(resolve)
-            .catch(reject);
-        }, waitTime - timeSinceLastCall);
-      }
-    });
-  };
-}
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const navigate = useNavigate();
@@ -57,9 +27,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [loading, setLoading] = useState(true);
   const [authConfig, setAuthConfig] = useState<AuthConfig | null>(null);
   const [retryCount, setRetryCount] = useState(0);
+  const [isChecking, setIsChecking] = useState(false);
 
   const checkAuthStatus = useCallback(async () => {
+    // Prevent concurrent auth checks
+    if (isChecking) {
+      console.log("[AuthProvider] Auth check already in progress, skipping");
+      return;
+    }
+
     console.log("[AuthProvider] Checking auth status");
+    setIsChecking(true);
+    
     try {
       const accessToken = localStorage.getItem("access_token");
       const currentAuthType = localStorage.getItem("auth_type") as
@@ -69,7 +48,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       if (!accessToken || !currentAuthType) {
         console.log("[AuthProvider] No access token or auth type found");
-        throw new Error("No access token or auth type");
+        clearAuth();
+        return;
+      }
+
+      // Skip check if we're already authenticated with matching token
+      if (isAuthenticated && user && accessToken === localStorage.getItem("access_token")) {
+        console.log("[AuthProvider] Already authenticated with same token, skipping check");
+        return;
       }
 
       console.log(
@@ -110,7 +96,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           "[AuthProvider] Token verification failed:",
           verifyResponse.status
         );
-        throw new Error("Token verification failed");
+        clearAuth();
+        return;
       }
 
       // Reset retry count on successful verification
@@ -118,13 +105,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       console.log("[AuthProvider] Token verified successfully");
 
       // Then get user info using the appropriate endpoint
-      const userInfoUrl =
-        currentAuthType === "oidc"
-          ? AUTH_URLS.oidc.userInfo
-          : AUTH_URLS.userInfo;
+      const isOIDC = currentAuthType === "oidc";
+      const userInfoUrl = isOIDC ? AUTH_URLS.oidc.userInfo : AUTH_URLS.userInfo;
 
       console.log("[AuthProvider] Fetching user info from:", userInfoUrl);
 
+      // Only make one userinfo request
       const userInfoResponse = await fetch(userInfoUrl, {
         headers: {
           Authorization: `Bearer ${accessToken}`,
@@ -150,7 +136,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           "[AuthProvider] Failed to get user info:",
           userInfoResponse.status
         );
-        throw new Error("Failed to get user info");
+        clearAuth();
+        return;
       }
 
       // Reset retry count on successful user info fetch
@@ -161,6 +148,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         auth_type: currentAuthType,
       });
 
+      // Only set authenticated after BOTH verify and userinfo succeed
       setUser({ ...userData, auth_type: currentAuthType });
       setIsAuthenticated(true);
       console.log("[AuthProvider] Authentication successful");
@@ -168,23 +156,31 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       console.error("[AuthProvider] Auth check failed:", error);
       clearAuth();
     } finally {
+      setIsChecking(false);
       setLoading(false);
     }
-  }, [retryCount]);
+  }, [retryCount, isAuthenticated, user, isChecking]);
 
-  // Debounce the auth check to prevent too frequent calls
-  const debouncedCheckAuth = useCallback(
-    (...args: []) => debounce(checkAuthStatus, 5000)(...args),
-    [checkAuthStatus]
-  );
+  const clearAuth = useCallback(() => {
+    console.log("[AuthProvider] Clearing authentication state");
+    localStorage.removeItem("access_token");
+    localStorage.removeItem("id_token");
+    localStorage.removeItem("auth_type");
+    setUser(null);
+    setIsAuthenticated(false);
+    setRetryCount(0);
+  }, []);
 
   useEffect(() => {
+    let mounted = true;
     console.log("[AuthProvider] Initializing auth provider");
 
     // Fetch auth configuration
     getAuthConfig().then((config) => {
-      console.log("[AuthProvider] Received auth config:", config);
-      setAuthConfig(config);
+      if (mounted) {
+        console.log("[AuthProvider] Received auth config:", config);
+        setAuthConfig(config);
+      }
     });
 
     // Check for OIDC auth tokens in URL (after callback)
@@ -199,37 +195,22 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       localStorage.setItem("id_token", idToken);
       localStorage.setItem("auth_type", "oidc");
       window.history.replaceState({}, document.title, window.location.pathname);
-      debouncedCheckAuth();
-    } else {
-      // Check if we have stored tokens
-      const storedAccessToken = localStorage.getItem("access_token");
-      const storedAuthType = localStorage.getItem("auth_type") as
-        | "oidc"
-        | "builtin"
-        | null;
-
-      console.log("[AuthProvider] Checking stored auth:", {
-        hasStoredToken: !!storedAccessToken,
-        storedAuthType,
-      });
-
-      if (storedAccessToken && storedAuthType) {
-        debouncedCheckAuth();
-      } else {
-        setLoading(false);
-      }
     }
-  }, [debouncedCheckAuth]);
 
-  const clearAuth = () => {
-    console.log("[AuthProvider] Clearing authentication state");
-    localStorage.removeItem("access_token");
-    localStorage.removeItem("id_token");
-    localStorage.removeItem("auth_type");
-    setIsAuthenticated(false);
-    setUser(null);
-    setRetryCount(0);
-  };
+    // Only do one initial auth check
+    const storedAccessToken = localStorage.getItem("access_token");
+    const storedAuthType = localStorage.getItem("auth_type");
+
+    if (storedAccessToken && storedAuthType && !isAuthenticated) {
+      checkAuthStatus();
+    } else {
+      setLoading(false);
+    }
+
+    return () => {
+      mounted = false;
+    };
+  }, []); // Empty deps array since we only want this to run once on mount
 
   const loginWithOIDC = () => {
     console.log("[AuthProvider] Initiating OIDC login");
@@ -269,7 +250,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       console.log("[AuthProvider] Login successful");
       localStorage.setItem("access_token", data.access_token);
       localStorage.setItem("auth_type", "builtin");
-      await debouncedCheckAuth();
+      await checkAuthStatus();
     } catch (error) {
       console.error("[AuthProvider] Login error:", error);
       throw error;

--- a/web/src/contexts/ConfigurationContext.tsx
+++ b/web/src/contexts/ConfigurationContext.tsx
@@ -32,9 +32,15 @@ export function ConfigurationProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const fetchConfigurations = useCallback(async () => {
-    if (!isAuthenticated) {
+    if (!isAuthenticated || !localStorage.getItem("access_token")) {
       setConfigurations({});
       setIsLoading(false);
+      return;
+    }
+
+    // Skip fetch if we already have configurations
+    if (Object.keys(configurations).length > 0) {
+      console.log("[ConfigurationProvider] Already have configurations, skipping fetch");
       return;
     }
 
@@ -48,6 +54,10 @@ export function ConfigurationProvider({ children }: { children: ReactNode }) {
       });
 
       if (!response.ok) {
+        if (response.status === 401) {
+          setConfigurations({});
+          return;
+        }
         throw new Error(`Failed to fetch configurations: ${response.status}`);
       }
 
@@ -61,7 +71,7 @@ export function ConfigurationProvider({ children }: { children: ReactNode }) {
     } finally {
       setIsLoading(false);
     }
-  }, [isAuthenticated, buildUrl, getAuthHeaders]);
+  }, [isAuthenticated, buildUrl, getAuthHeaders, configurations]);
 
   useEffect(() => {
     fetchConfigurations();

--- a/web/src/hooks/useEventSource.ts
+++ b/web/src/hooks/useEventSource.ts
@@ -132,24 +132,21 @@ export const useEventSource = <T extends EventData>(
   // Connection health check
   useEffect(() => {
     const healthCheckInterval = setInterval(() => {
-      if (!mountedRef.current) return;
+      if (!mountedRef.current || !eventSourceRef.current) return;
 
-      const now = Date.now();
-      const messageAge = now - lastMessageTimeRef.current;
+      const messageAge = Date.now() - lastMessageTimeRef.current;
 
-      // If no message received in MESSAGE_TIMEOUT, reconnect
-      if (isConnected && messageAge > MESSAGE_TIMEOUT && eventSourceRef.current) {
-        console.warn('[EventSource] No messages received for 5 minutes, reconnecting...');
+      // Only log and cleanup if we're not authenticated - prevents unnecessary userinfo requests
+      if (messageAge > MESSAGE_TIMEOUT && !isAuthenticated) {
+        console.warn('[EventSource] Connection stale and not authenticated, cleaning up...');
         cleanup();
-        retryCountRef.current = 0; // Reset retry count for fresh connection
-        authErrorRef.current = false; // Reset auth error flag
       }
     }, HEALTH_CHECK_INTERVAL);
 
     return () => {
       clearInterval(healthCheckInterval);
     };
-  }, [isConnected, cleanup]);
+  }, [isAuthenticated, cleanup]);
 
   // Main EventSource connection logic
   useEffect(() => {
@@ -194,7 +191,10 @@ export const useEventSource = <T extends EventData>(
           setIsConnected(true);
           retryCountRef.current = 0; // Reset retry count on successful connection
           lastMessageTimeRef.current = Date.now();
-          authErrorRef.current = false;
+          if (authErrorRef.current) {
+            console.log('[EventSource] Resetting auth error after successful connection');
+            authErrorRef.current = false;
+          }
         };
 
         eventSource.onmessage = (event) => {
@@ -253,6 +253,8 @@ export const useEventSource = <T extends EventData>(
             
             if (status === 401 || status === 403 || !isAuthenticated || !localStorage.getItem('access_token')) {
               errorType = EventSourceErrorType.AUTH;
+              console.log('[EventSource] Auth error detected, preventing reconnection attempts');
+              authErrorRef.current = true;
             } else if (status === 429) {
               errorType = EventSourceErrorType.RATE_LIMIT;
               const retryHeader = target.getResponseHeader?.('Retry-After');
@@ -279,14 +281,13 @@ export const useEventSource = <T extends EventData>(
           switch (errorType) {
             case EventSourceErrorType.AUTH: {
               console.error('[EventSource] Authentication error detected');
-              authErrorRef.current = true;
-              return;
+              return; // Don't attempt to reconnect on auth errors
             }
 
             case EventSourceErrorType.RATE_LIMIT: {
               if (retryAfter) {
                 reconnectTimeoutRef.current = window.setTimeout(() => {
-                  if (mountedRef.current) {
+                  if (mountedRef.current && !authErrorRef.current) {
                     console.log('[EventSource] Retrying after rate limit');
                     connectionLockRef.current = false;
                     connect();
@@ -307,7 +308,7 @@ export const useEventSource = <T extends EventData>(
                 retryCountRef.current++;
                 
                 reconnectTimeoutRef.current = window.setTimeout(() => {
-                  if (mountedRef.current) {
+                  if (mountedRef.current && !authErrorRef.current) {
                     console.log(`[EventSource] Attempting reconnection (${retryCountRef.current}/${maxRetries})`);
                     connectionLockRef.current = false;
                     connect();
@@ -343,10 +344,10 @@ export const useEventSource = <T extends EventData>(
     };
   }, [path, isAuthenticated, onMessage, onError, maxRetries, reconnectInterval, cleanup, getBackoffDelay, processPendingUpdates]);
 
-  // Reset auth error flag when auth state changes
+  // Only reset auth error when we get a successful connection
   useEffect(() => {
-    if (isAuthenticated) {
-      authErrorRef.current = false;
+    if (!isAuthenticated) {
+      authErrorRef.current = true;
     }
   }, [isAuthenticated]);
 

--- a/web/src/hooks/useServiceData.ts
+++ b/web/src/hooks/useServiceData.ts
@@ -65,6 +65,7 @@ export const useServiceData = () => {
   const configHashRef = useRef<string>('');
   const isInitialLoadRef = useRef(true);
   const eventSourceRef = useRef<EventSource | null>(null);
+  const mountedRef = useRef(true);
 
   const clearServiceTimeout = useCallback((serviceId: string) => {
     const timeoutId = updateTimeoutsRef.current.get(serviceId);
@@ -774,12 +775,17 @@ const updateService = useCallback((service: Service) => {
 
     eventSource.onerror = (error) => {
       console.error('SSE connection error:', error);
-      eventSource.close();
-      setTimeout(initializeSSE, 5000);
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close();
+      }
+      // Only retry if we're still mounted and authenticated
+      if (isAuthenticated && mountedRef.current) {
+        initializeSSE();  // Retry immediately instead of waiting
+      }
     };
 
     eventSourceRef.current = eventSource;
-  }, [updateServiceData, services]);
+  }, [updateServiceData, services, isAuthenticated]);
 
   useEffect(() => {
     if (!isAuthenticated || !configurations) {
@@ -788,15 +794,16 @@ const updateService = useCallback((service: Service) => {
       return;
     }
 
-    const currentPlexTimeout = plexTimeoutRef.current;
     const configHash = JSON.stringify(configurations);
-    
     if (configHash === configHashRef.current && !isInitialLoadRef.current) {
       return;
     }
     
     configHashRef.current = configHash;
-    initializeSSE();
+    
+    if (isAuthenticated) {
+      initializeSSE();
+    }
 
     Object.entries(configurations).forEach(([instanceId, config]) => {
       const existingService = services.get(instanceId);
@@ -832,12 +839,13 @@ const updateService = useCallback((service: Service) => {
 
     return () => {
       Array.from(services.keys()).forEach(clearServiceTimeout);
-      if (currentPlexTimeout) {
-        clearTimeout(currentPlexTimeout);
+      if (plexTimeoutRef.current) {
+        clearTimeout(plexTimeoutRef.current);
       }
       if (eventSourceRef.current) {
         eventSourceRef.current.close();
       }
+      mountedRef.current = false;
     };
   }, [configurations, isAuthenticated, clearServiceTimeout, initializeService, updateService, services, initializeSSE]);
 
@@ -870,5 +878,3 @@ const updateService = useCallback((service: Service) => {
     refreshService: debouncedRefreshService
   };
 };
-
-

--- a/web/src/hooks/useServiceData.ts
+++ b/web/src/hooks/useServiceData.ts
@@ -837,13 +837,17 @@ const updateService = useCallback((service: Service) => {
     setIsLoading(false);
     isInitialLoadRef.current = false;
 
+    // Store refs in variables to ensure we have the correct values during cleanup
+    const currentPlexTimeout = plexTimeoutRef.current;
+    const currentEventSource = eventSourceRef.current;
+
     return () => {
       Array.from(services.keys()).forEach(clearServiceTimeout);
-      if (plexTimeoutRef.current) {
-        clearTimeout(plexTimeoutRef.current);
+      if (currentPlexTimeout) {
+        clearTimeout(currentPlexTimeout);
       }
-      if (eventSourceRef.current) {
-        eventSourceRef.current.close();
+      if (currentEventSource) {
+        currentEventSource.close();
       }
       mountedRef.current = false;
     };

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -147,6 +147,9 @@ const isAuthEndpoint = (path: string): boolean => {
   return authPaths.some(authPath => path.includes(authPath));
 };
 
+// Track auth state changes to prevent cascading 401 handlers
+let isHandlingAuth = false;
+
 const handleRequest = async <T>(
   path: string,
   options: RequestOptions,
@@ -171,14 +174,24 @@ const handleRequest = async <T>(
     clearTimeout(timeoutId);
 
     if (response.status === 401) {
-      // Only trigger logout for authentication-related 401s
+      // Prevent multiple auth handlers from running simultaneously
+      if (isHandlingAuth) {
+        throw new Error('Authentication in progress');
+      }
+
+      // Only handle auth once
       if (isAuthEndpoint(path)) {
-        localStorage.removeItem('access_token');
-        localStorage.removeItem('id_token');
-        localStorage.removeItem('auth_type');
-        await unregisterServiceWorker();
-        window.location.href = '/login';
-        throw new Error('Authentication required');
+        isHandlingAuth = true;
+        try {
+          localStorage.removeItem('access_token');
+          localStorage.removeItem('id_token');
+          localStorage.removeItem('auth_type');
+          await unregisterServiceWorker();
+          window.location.href = '/login';
+          throw new Error('Authentication required');
+        } finally {
+          isHandlingAuth = false;
+        }
       } else {
         // For service-related 401s (like invalid API keys), just throw an error
         const errorData = await response.json().catch(() => ({ error: 'Unauthorized' }));


### PR DESCRIPTION
Spec: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationRequest

```console
6:25AM INFO Starting dashbrr build_date= commit= version=dev
6:25AM DEBUG Loading config file path=config.toml
6:25AM DEBUG Loaded existing configuration file path=~/github/autobrr/dashbrr/config.toml
6:25AM DEBUG Initializing SQLite database path=./data/dashbrr.db
6:25AM INFO Successfully connected to database driver=sqlite
6:25AM DEBUG Cache initialized type=memory

6:25AM DEBUG initializing auth handler issuer=https://dev-redacted.us.auth0.com/
6:25AM DEBUG attempting to fetch provider configuration issuer=https://dev-redacted.us.auth0.com well_known_url=https://dev-redacted.us.auth0.com/.well-known/openid-configuration
6:25AM DEBUG using discovered endpoints auth_url=https://dev-redacted.us.auth0.com/authorize token_url=https://dev-redacted.us.auth0.com/oauth/token

6:25AM INFO Health monitor started with client cleanup
6:25AM INFO Starting server address=:8080 database=./data/dashbrr.db mode=release
```