### PR TITLE
fix(web): use autobrr access URL

### DIFF
--- a/web/src/components/services/autobrr/AutobrrStats.tsx
+++ b/web/src/components/services/autobrr/AutobrrStats.tsx
@@ -64,7 +64,7 @@ export const AutobrrStats: React.FC<AutobrrStatsProps> = ({ instanceId }) => {
 
   const showMessage = service.message || service.status !== "online";
 
-  const baseUrl = service?.url || "";
+  const baseUrl = service?.accessUrl || service?.url || "";
 
   // Function to construct the full URL for releases
   const getReleasesUrl = (actionStatus?: string) => {


### PR DESCRIPTION
The access URL should be used to access autobrr releases from the UI