### PR TITLE
fix(maintainerr): align Collection/Media structs with current Maintainerr API

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,15 +1,4 @@
-# These are supported funding model platforms
-
 github: [s0up4200, zze0s]
-patreon: # Replace with a single Patreon username
-open_collective: # Replace with a single Open Collective username
-ko_fi: # Replace with a single Ko-fi username
-tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
-liberapay: # Replace with a single Liberapay username
-issuehunt: # Replace with a single IssueHunt username
-lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
-polar: # Replace with a single Polar username
-buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
-thanks_dev: # Replace with a single thanks.dev username
-custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+patreon: s0up4200
+buy_me_a_coffee: s0up4200
+ko_fi: s0up4200

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
         with:
           version: latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,12 +39,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -53,7 +53,7 @@ jobs:
 
       # It can not be done before enable corepack
       - name: Set up cache
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           cache: pnpm
           cache-dependency-path: web/pnpm-lock.yaml
@@ -67,7 +67,7 @@ jobs:
         run: CI= pnpm run build
 
       - name: Upload web production build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: web-dist
           path: web/dist
@@ -77,12 +77,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -91,7 +91,7 @@ jobs:
 
       # It can not be done before enable corepack
       - name: Set up cache
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           cache: pnpm
           cache-dependency-path: web/pnpm-lock.yaml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: |
@@ -133,13 +133,13 @@ jobs:
         options: --health-cmd pg_isready --health-interval 1s --health-timeout 5s --health-retries 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       # 1.20 is the last version to support Windows < 10, Server < 2016, and MacOS < 1.15.
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -170,26 +170,26 @@ jobs:
     needs: [web, test]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Download web production build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: web-dist
           path: web/dist
 
       #     1.20 is the last version to support Windows < 10, Server < 2016, and MacOS < 1.15.
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Run GoReleaser build
         if: github.event_name == 'pull_request'
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -199,7 +199,7 @@ jobs:
 
       - name: Run GoReleaser build and publish tags
         if: startsWith(github.ref, 'refs/tags/')
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -219,7 +219,7 @@ jobs:
             dist/web-dist.tar.gz
 
       - name: Upload assets
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dashbrr
           path: |
@@ -253,18 +253,18 @@ jobs:
     needs: [web, test]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Download web production build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: web-dist
           path: web/dist
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
@@ -272,7 +272,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           images: ${{ env.REGISTRY_IMAGE }}
@@ -285,17 +285,17 @@ jobs:
             latest=auto
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Supported Architectures
         run: docker buildx ls
 
       - name: Build and publish image
         id: docker_build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./ci.Dockerfile
@@ -319,7 +319,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload image digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docker-digests-${{ steps.digest-prep.outputs.manifest-hash }}
           path: /tmp/digests/*
@@ -333,17 +333,17 @@ jobs:
     needs: [docker, test]
     steps:
       - name: Download image digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/digests
           pattern: docker-digests-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
@@ -351,7 +351,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           images: ${{ env.REGISTRY_IMAGE }}

--- a/internal/services/cache/memory.go
+++ b/internal/services/cache/memory.go
@@ -165,10 +165,16 @@ func (s *MemoryStore) Get(_ context.Context, key string, value any) error {
 		s.local.RUnlock()
 		return json.Unmarshal(item.value, value)
 	}
-	if exists {
-		delete(s.local.items, key)
-	}
 	s.local.RUnlock()
+
+	// Expired entries must be deleted under write lock.
+	if exists {
+		s.local.Lock()
+		if current, ok := s.local.items[key]; ok && !time.Now().Before(current.expiration) {
+			delete(s.local.items, key)
+		}
+		s.local.Unlock()
+	}
 
 	return ErrKeyNotFound
 }

--- a/internal/services/cache/memory_test.go
+++ b/internal/services/cache/memory_test.go
@@ -5,6 +5,7 @@ package cache
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 )
@@ -212,5 +213,41 @@ func TestMemoryStorePersistence(t *testing.T) {
 	}
 	if result != "test_value" {
 		t.Errorf("Expected 'test_value', got '%v'", result)
+	}
+}
+
+func TestMemoryStoreGetExpiredKeyConcurrentDoesNotPanic(t *testing.T) {
+	tempDir := t.TempDir()
+	store := NewMemoryStore(context.Background(), tempDir)
+	defer store.Close()
+
+	ctx := context.Background()
+	const key = "expired-key"
+
+	if err := store.Set(ctx, key, "value", 10*time.Millisecond); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+
+	time.Sleep(25 * time.Millisecond)
+
+	const workers = 32
+	const iterations = 200
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			var out string
+			for range iterations {
+				_ = store.Get(ctx, key, &out)
+			}
+		}()
+	}
+	wg.Wait()
+
+	var out string
+	if err := store.Get(ctx, key, &out); err != ErrKeyNotFound {
+		t.Fatalf("expected ErrKeyNotFound, got %v", err)
 	}
 }

--- a/internal/services/core/service.go
+++ b/internal/services/core/service.go
@@ -45,6 +45,20 @@ var (
 	DefaultLongTimeout = 60 * time.Second // Added for services that need longer timeouts
 )
 
+type cancelOnCloseReadCloser struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+	once   sync.Once
+}
+
+func (r *cancelOnCloseReadCloser) Close() error {
+	err := r.ReadCloser.Close()
+	if r.cancel != nil {
+		r.once.Do(r.cancel)
+	}
+	return err
+}
+
 type ServiceCore struct {
 	Type           string
 	DisplayName    string
@@ -122,7 +136,6 @@ func (s *ServiceCore) DoRequest(ctx context.Context, method string, url string, 
 	var cancel context.CancelFunc
 	if _, ok := ctx.Deadline(); !ok && timeout > 0 {
 		reqCtx, cancel = context.WithTimeout(ctx, timeout)
-		defer cancel()
 	}
 
 	var bodyReader io.Reader
@@ -148,6 +161,9 @@ func (s *ServiceCore) DoRequest(ctx context.Context, method string, url string, 
 	start := time.Now()
 	resp, err := httpClient.Do(req)
 	if err != nil {
+		if cancel != nil {
+			cancel()
+		}
 		log.Error().Err(err).
 			Str("url", url).
 			Dur("timeout", timeout).
@@ -155,8 +171,17 @@ func (s *ServiceCore) DoRequest(ctx context.Context, method string, url string, 
 		return nil, err
 	}
 	if resp == nil {
+		if cancel != nil {
+			cancel()
+		}
 		log.Error().Str("url", url).Msg("Received nil response from server")
 		return nil, ErrNilResponse
+	}
+	if cancel != nil {
+		resp.Body = &cancelOnCloseReadCloser{
+			ReadCloser: resp.Body,
+			cancel:     cancel,
+		}
 	}
 
 	// Redirect often indicates auth issues.
@@ -194,13 +219,11 @@ func (s *ServiceCore) ReadBody(resp *http.Response) ([]byte, error) {
 	// Read the entire body at once
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		if errors.Is(err, context.Canceled) {
-			if len(body) > 0 {
-				log.Debug().
-					Str("body", string(body)).
-					Msg("Context canceled but partial response received")
-				return body, nil
-			}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			log.Debug().
+				Err(err).
+				Int("partial_bytes", len(body)).
+				Msg("Response body read interrupted by context cancellation")
 			return nil, ErrContextCanceled
 		}
 

--- a/internal/services/core/service_test.go
+++ b/internal/services/core/service_test.go
@@ -5,11 +5,33 @@ package core
 
 import (
 	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/autobrr/dashbrr/internal/services/cache"
 )
+
+type partialCanceledReadCloser struct {
+	read bool
+}
+
+func (r *partialCanceledReadCloser) Read(p []byte) (int, error) {
+	if r.read {
+		return 0, context.Canceled
+	}
+	r.read = true
+	payload := []byte(`{"devices":[`)
+	copy(p, payload)
+	return len(payload), context.Canceled
+}
+
+func (r *partialCanceledReadCloser) Close() error {
+	return nil
+}
 
 func TestCacheUpdateStatusRoundTrip(t *testing.T) {
 	t.Parallel()
@@ -47,6 +69,60 @@ func TestCacheUpdateStatusRoundTrip(t *testing.T) {
 	}
 	if got {
 		t.Fatalf("expected cached value false, got true")
+	}
+}
+
+func TestDoRequest_DelayedBodyReadableAfterReturn(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			_, _ = w.Write([]byte("hello "))
+			flusher.Flush()
+		}
+		time.Sleep(150 * time.Millisecond)
+		_, _ = w.Write([]byte("world"))
+	}))
+	defer srv.Close()
+
+	s := &ServiceCore{}
+	s.SetTimeout(time.Second)
+
+	resp, err := s.DoRequest(context.Background(), http.MethodGet, srv.URL, nil, nil)
+	if err != nil {
+		t.Fatalf("DoRequest failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+	if string(body) != "hello world" {
+		t.Fatalf("unexpected response body: %q", string(body))
+	}
+}
+
+func TestReadBody_PartialCanceledReadReturnsContextCanceled(t *testing.T) {
+	t.Parallel()
+
+	s := &ServiceCore{}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       &partialCanceledReadCloser{},
+	}
+
+	body, err := s.ReadBody(resp)
+	if err == nil {
+		t.Fatalf("expected read error")
+	}
+	if !errors.Is(err, ErrContextCanceled) {
+		t.Fatalf("expected ErrContextCanceled, got: %v", err)
+	}
+	if body != nil {
+		t.Fatalf("expected nil body, got %q", string(body))
 	}
 }
 

--- a/internal/services/maintainerr/maintainerr.go
+++ b/internal/services/maintainerr/maintainerr.go
@@ -54,19 +54,18 @@ type StatusResponse struct {
 }
 
 type Media struct {
-	ID           int       `json:"id"`
-	CollectionID int       `json:"collectionId"`
-	PlexID       int       `json:"plexId"`
-	TmdbID       int       `json:"tmdbId"`
-	AddDate      time.Time `json:"addDate"`
-	ImagePath    string    `json:"image_path"`
-	IsManual     bool      `json:"isManual"`
+	ID             int    `json:"id"`
+	CollectionID   int    `json:"collectionId"`
+	MediaServerID  string `json:"mediaServerId"`
+	TmdbID         int    `json:"tmdbId"`
+	AddDate        string `json:"addDate"`
+	ImagePath      string `json:"image_path"`
+	IsManual       bool   `json:"isManual"`
 }
 
 type Collection struct {
 	ID                int     `json:"id"`
-	PlexID            int     `json:"plexId"`
-	LibraryID         int     `json:"libraryId"`
+	LibraryID         string  `json:"libraryId"`
 	Title             string  `json:"title"`
 	Description       string  `json:"description"`
 	IsActive          bool    `json:"isActive"`
@@ -75,11 +74,12 @@ type Collection struct {
 	DeleteAfterDays   int     `json:"deleteAfterDays"`
 	ManualCollection  bool    `json:"manualCollection"`
 	ListExclusions    bool    `json:"listExclusions"`
-	ForceOverseerr    bool    `json:"forceOverseerr"`
-	Type              int     `json:"type"`
+	ForceSeerr        bool    `json:"forceSeerr"`
+	Type              string  `json:"type"`
 	KeepLogsForMonths int     `json:"keepLogsForMonths"`
 	AddDate           string  `json:"addDate"`
 	Media             []Media `json:"media"`
+	MediaCount        int     `json:"mediaCount"`
 }
 
 func init() {

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -1845,8 +1845,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ajv@6.12.6:
-    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+  ajv@6.14.0:
+    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
@@ -1924,6 +1924,10 @@ packages:
     resolution: {integrity: sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==}
     engines: {node: 20 || >=22}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
@@ -1944,6 +1948,10 @@ packages:
   brace-expansion@5.0.2:
     resolution: {integrity: sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==}
     engines: {node: 20 || >=22}
+
+  brace-expansion@5.0.3:
+    resolution: {integrity: sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2820,19 +2828,19 @@ packages:
     resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
     hasBin: true
 
-  minimatch@10.2.1:
-    resolution: {integrity: sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==}
-    engines: {node: 20 || >=22}
+  minimatch@10.2.3:
+    resolution: {integrity: sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==}
+    engines: {node: 18 || 20 || >=22}
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+  minimatch@3.1.4:
+    resolution: {integrity: sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==}
 
-  minimatch@5.1.6:
-    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
+  minimatch@5.1.8:
+    resolution: {integrity: sha512-7RN35vit8DeBclkofOVmBY0eDAZZQd1HzmukRdSyz95CRh8FT54eqnbj0krQr3mrHR6sfRyYkyhwBWjoV5uqlQ==}
     engines: {node: '>=10'}
 
-  minimatch@9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+  minimatch@9.0.7:
+    resolution: {integrity: sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minipass@7.1.2:
@@ -4553,7 +4561,7 @@ snapshots:
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3
-      minimatch: 3.1.2
+      minimatch: 3.1.4
     transitivePeerDependencies:
       - supports-color
 
@@ -4567,14 +4575,14 @@ snapshots:
 
   '@eslint/eslintrc@3.3.3':
     dependencies:
-      ajv: 6.12.6
+      ajv: 6.14.0
       debug: 4.4.3
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.1.1
-      minimatch: 3.1.2
+      minimatch: 3.1.4
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -5343,7 +5351,7 @@ snapshots:
       '@typescript-eslint/types': 8.56.0
       '@typescript-eslint/visitor-keys': 8.56.0
       debug: 4.4.3
-      minimatch: 9.0.5
+      minimatch: 9.0.7
       semver: 7.7.4
       tinyglobby: 0.2.15
       ts-api-utils: 2.4.0(typescript@5.9.3)
@@ -5439,7 +5447,7 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  ajv@6.12.6:
+  ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
@@ -5538,6 +5546,8 @@ snapshots:
     dependencies:
       jackspeak: 4.2.3
 
+  balanced-match@4.0.4: {}
+
   baseline-browser-mapping@2.9.19: {}
 
   binary-extensions@2.3.0: {}
@@ -5556,6 +5566,10 @@ snapshots:
   brace-expansion@5.0.2:
     dependencies:
       balanced-match: 4.0.2
+
+  brace-expansion@5.0.3:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -5942,7 +5956,7 @@ snapshots:
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
       '@types/estree': 1.0.8
-      ajv: 6.12.6
+      ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3
@@ -5961,7 +5975,7 @@ snapshots:
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.2
+      minimatch: 3.1.4
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
@@ -6023,7 +6037,7 @@ snapshots:
 
   filelist@1.0.4:
     dependencies:
-      minimatch: 5.1.6
+      minimatch: 5.1.8
 
   fill-range@7.1.1:
     dependencies:
@@ -6126,7 +6140,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.2.3
-      minimatch: 10.2.1
+      minimatch: 10.2.3
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.1
@@ -6482,21 +6496,21 @@ snapshots:
 
   mini-svg-data-uri@1.4.4: {}
 
-  minimatch@10.2.1:
+  minimatch@10.2.3:
     dependencies:
       brace-expansion: 5.0.2
 
-  minimatch@3.1.2:
+  minimatch@3.1.4:
     dependencies:
       brace-expansion: 1.1.12
 
-  minimatch@5.1.6:
+  minimatch@5.1.8:
     dependencies:
       brace-expansion: 2.0.2
 
-  minimatch@9.0.5:
+  minimatch@9.0.7:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 5.0.3
 
   minipass@7.1.2: {}
 

--- a/web/src/AppContent.tsx
+++ b/web/src/AppContent.tsx
@@ -34,10 +34,6 @@ export default function AppContent() {
   const { logout } = useAuth();
   const { services } = useServiceHealth();
 
-  const handleTailscaleConfig = () => {
-    addServiceInstance("tailscale", "Tailscale");
-  };
-
   return (
     <div
       className="min-h-screen bg-color pattern flex flex-col"
@@ -79,7 +75,7 @@ export default function AppContent() {
                 </span>
               </div>
               <div className="hidden sm:flex items-center gap-4">
-                <TailscaleStatusBar onConfigOpen={handleTailscaleConfig} />
+                <TailscaleStatusBar />
                 <button
                   onClick={logout}
                   className="p-1 text-zinc-400 hover:text-zinc-600 dark:hover:text-white"
@@ -99,7 +95,7 @@ export default function AppContent() {
               </button>
             </div>
             <div className="sm:hidden flex justify-center w-full mt-2">
-              <TailscaleStatusBar onConfigOpen={handleTailscaleConfig} />
+              <TailscaleStatusBar />
             </div>
           </div>
         </header>

--- a/web/src/components/configuration/ConfigurationForm.tsx
+++ b/web/src/components/configuration/ConfigurationForm.tsx
@@ -172,13 +172,13 @@ export const ConfigurationForm = ({
             serviceType === "sabnzbd"
               ? "Config > General"
               : serviceType === "nzbget"
-                ? "Config > Security"
+                ? "Settings > Security"
                 : "Settings > General",
           link:
             serviceType === "sabnzbd"
               ? getSettingsUrl("/config/general/")
               : serviceType === "nzbget"
-                ? getSettingsUrl("/?tab=config#S_SECURITY")
+                ? getSettingsUrl("/#settings")
               : getSettingsUrl("/settings/general"),
         };
       case "jellyfin":

--- a/web/src/components/services/TailscaleStatusBar.tsx
+++ b/web/src/components/services/TailscaleStatusBar.tsx
@@ -13,13 +13,7 @@ import AnimatedModal from "../ui/AnimatedModal";
 import { useServiceData } from "../../hooks/useServiceData";
 import { TailscaleDevice } from "../../types/service";
 
-interface TailscaleStatusBarProps {
-  onConfigOpen?: () => void;
-}
-
-export const TailscaleStatusBar: React.FC<TailscaleStatusBarProps> = ({
-  onConfigOpen,
-}) => {
+export const TailscaleStatusBar: React.FC = () => {
   const [isDeviceModalOpen, setIsDeviceModalOpen] = useState(false);
   const { configurations } = useConfiguration();
   const { removeServiceInstance } = useServiceManagement();
@@ -95,39 +89,8 @@ export const TailscaleStatusBar: React.FC<TailscaleStatusBarProps> = ({
     );
   };
 
-  // Render a minimal "add/configure" affordance even when not configured.
   if (!instanceId) {
-    return (
-      <button
-        onClick={onConfigOpen}
-        disabled={!onConfigOpen}
-        className="flex items-center gap-2 text-zinc-300 hover:text-blue-400 transition-colors disabled:opacity-50 disabled:hover:text-zinc-300"
-        title="Add Tailscale"
-      >
-        <div className="w-6 pb-1">
-          <img
-            src={tailscaleLogo}
-            alt="Tailscale"
-            className="w-full h-full"
-            draggable="false"
-            style={{
-              pointerEvents: "none",
-              userSelect: "none",
-              WebkitUserSelect: "none",
-              MozUserSelect: "none",
-              msUserSelect: "none",
-            }}
-            onContextMenu={(e) => e.preventDefault()}
-          />
-        </div>
-        <div className="text-sm flex items-center justify-center">
-          <>
-            Tailscale:
-            <span className="text-yellow-500 ml-1">Add</span>
-          </>
-        </div>
-      </button>
-    );
+    return null;
   }
 
   return (

--- a/web/src/components/services/autobrr/AutobrrStats.tsx
+++ b/web/src/components/services/autobrr/AutobrrStats.tsx
@@ -64,7 +64,7 @@ export const AutobrrStats: React.FC<AutobrrStatsProps> = ({ instanceId }) => {
 
   const showMessage = service.message || service.status !== "online";
 
-  const baseUrl = service?.url || "";
+  const baseUrl = service?.accessUrl || service?.url || "";
 
   // Function to construct the full URL for releases
   const getReleasesUrl = (actionStatus?: string) => {

--- a/web/src/types/service.ts
+++ b/web/src/types/service.ts
@@ -160,7 +160,7 @@ export interface AutobrrActionStatus {
 export interface MaintainerrMedia {
   id: number;
   collectionId: number;
-  plexId: number;
+  mediaServerId: string;
   tmdbId: number;
   addDate: string;
   image_path: string;


### PR DESCRIPTION
## Problem

The `maintainerr_collections` poller job fails with:

```
WARN poller job failed error="maintainerr get_collections: failed to parse response: json: cannot unmarshal array into Go value of type maintainerr.Collection"
```

Reported in #95 and #98.

## Root cause

`/api/collections` returns `libraryId` as a **string** (it's a `varchar` column in Maintainerr's database) and `type` as a **string enum** (`"movie"` / `"show"`). The dashbrr structs declared both as `int`, so `json.Unmarshal(body, &[]Collection{})` fails. The fallback path then tries to unmarshal the same array body into a single `Collection`, which fails with the reported message.

## Changes

**`internal/services/maintainerr/maintainerr.go`**

| Field | Before | After | Reason |
|---|---|---|---|
| `Collection.LibraryID` | `int` | `string` | varchar in Maintainerr DB |
| `Collection.Type` | `int` | `string` | string enum (`"movie"`, `"show"`) |
| `Collection.ForceOverseerr` json:`"forceOverseerr"` | `bool` | removed/renamed | field is `forceSeerr` in Maintainerr |
| `Collection.ForceSeerr` json:`"forceSeerr"` | — | `bool` | correct field name |
| `Collection.PlexID` | `int` | removed | no such field in Maintainerr's entity |
| `Collection.MediaCount` | — | `int` | `getCollections` returns `mediaCount` |
| `Media.PlexID` json:`"plexId"` | `int` | removed | Maintainerr uses `mediaServerId` |
| `Media.MediaServerID` json:`"mediaServerId"` | — | `string` | correct field name |
| `Media.AddDate` | `time.Time` | `string` | avoids fragile RFC3339 parsing |

**`web/src/types/service.ts`**

`MaintainerrMedia.plexId: number` → `mediaServerId: string` to match.

## Testing

Verified against Maintainerr source (`collection.entities.ts`, `collection_media.entities.ts`, `collections.service.ts`). The `libraryId` field is declared as `@Column({ type: 'varchar' })` and `type` as `MediaItemType` (string enum).

Closes #95, #98