### PR TITLE
fix(discovery): negotiate Docker API version to support daemon >1.47

### DIFF
--- a/internal/services/discovery/docker.go
+++ b/internal/services/discovery/docker.go
@@ -20,7 +20,7 @@ type DockerDiscovery struct {
 
 // NewDockerDiscovery creates a new Docker discovery instance
 func NewDockerDiscovery() (*DockerDiscovery, error) {
-	cli, err := client.NewClientWithOpts(client.FromEnv)
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Docker client: %w", err)
 	}


### PR DESCRIPTION
## Problem

When connecting to a Docker daemon with API version above 1.47 (Docker Engine 27+), dashbrr fails with an API version mismatch error because the client uses a fixed compile-time API version.

## Fix

Add `client.WithAPIVersionNegotiation()` to the Docker client options. This makes the SDK automatically negotiate the highest API version supported by both client and daemon on the first request, which is the recommended approach per the Docker SDK docs.

```go
// Before
cli, err := client.NewClientWithOpts(client.FromEnv)

// After
cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
```

## Impact

- No breaking changes — `WithAPIVersionNegotiation()` is backwards-compatible with all daemon versions
- Fixes service discovery for users running Docker Engine 27+ (API >1.47)