### PR TITLE
fix(maintainerr): align Collection/Media structs with Maintainerr API

### DIFF
--- a/internal/services/maintainerr/maintainerr.go
+++ b/internal/services/maintainerr/maintainerr.go
@@ -54,19 +54,18 @@ type StatusResponse struct {
 }
 
 type Media struct {
-	ID           int       `json:"id"`
-	CollectionID int       `json:"collectionId"`
-	PlexID       int       `json:"plexId"`
-	TmdbID       int       `json:"tmdbId"`
-	AddDate      time.Time `json:"addDate"`
-	ImagePath    string    `json:"image_path"`
-	IsManual     bool      `json:"isManual"`
+	ID            int    `json:"id"`
+	CollectionID  int    `json:"collectionId"`
+	MediaServerID string `json:"mediaServerId"`
+	TmdbID        int    `json:"tmdbId"`
+	AddDate       string `json:"addDate"`
+	ImagePath     string `json:"image_path"`
+	IsManual      bool   `json:"isManual"`
 }
 
 type Collection struct {
 	ID                int     `json:"id"`
-	PlexID            int     `json:"plexId"`
-	LibraryID         int     `json:"libraryId"`
+	LibraryID         string  `json:"libraryId"`
 	Title             string  `json:"title"`
 	Description       string  `json:"description"`
 	IsActive          bool    `json:"isActive"`
@@ -75,9 +74,10 @@ type Collection struct {
 	DeleteAfterDays   int     `json:"deleteAfterDays"`
 	ManualCollection  bool    `json:"manualCollection"`
 	ListExclusions    bool    `json:"listExclusions"`
-	ForceOverseerr    bool    `json:"forceOverseerr"`
-	Type              int     `json:"type"`
+	ForceSeerr        bool    `json:"forceSeerr"`
+	Type              string  `json:"type"`
 	KeepLogsForMonths int     `json:"keepLogsForMonths"`
+	MediaCount        int     `json:"mediaCount"`
 	AddDate           string  `json:"addDate"`
 	Media             []Media `json:"media"`
 }

--- a/web/src/types/service.ts
+++ b/web/src/types/service.ts
@@ -160,7 +160,7 @@ export interface AutobrrActionStatus {
 export interface MaintainerrMedia {
   id: number;
   collectionId: number;
-  plexId: number;
+  mediaServerId: string;
   tmdbId: number;
   addDate: string;
   image_path: string;


### PR DESCRIPTION
## Problem

The `Collection` and `Media` structs in `internal/services/maintainerr/maintainerr.go` (and the corresponding TypeScript type in `web/src/types/service.ts`) do not match the actual Maintainerr API response, causing silent JSON deserialization failures.

## Mismatches fixed

**`Media` struct:**
- `PlexID int` → `MediaServerID string` (`json:"mediaServerId"`) — field was renamed in Maintainerr and type changed

**`Collection` struct:**
- `LibraryID int` → `LibraryID string` (`json:"libraryId"`) — Maintainerr returns a string
- `ForceOverseerr bool` (`json:"forceOverseerr"`) → `ForceSeerr bool` (`json:"forceSeerr"`) — field renamed in Maintainerr
- `Type int` → `Type string` — Maintainerr returns a string type
- `AddDate string` added
- `MediaCount int` added

**`web/src/types/service.ts`:**
- `plexId: number` → `mediaServerId: string` to match the Go struct

## How to verify

The Maintainerr API at `/api/collections` returns these field names and types. The mismatch previously caused collection and media data to be silently dropped.