### PR TITLE
fix(sabnzbd): tolerate numeric noofslots/noofslots_total in queue response

### DIFF
--- a/internal/api/handlers/sabnzbd.go
+++ b/internal/api/handlers/sabnzbd.go
@@ -110,7 +110,7 @@ func (h *SabnzbdHandler) compareAndLogSummaryChanges(instanceID string, summary 
 	log.Debug().
 		Str("instanceId", instanceID).
 		Str("status", summary.Queue.Status).
-		Str("queue", summary.Queue.NoOfSlots).
+		Str("queue", string(summary.Queue.NoOfSlots)).
 		Int("failed", summary.FailedCount).
 		Str("warnings", summary.Queue.HaveWarnings).
 		Str("change", change).
@@ -134,7 +134,7 @@ func createSabnzbdSummaryHash(summary *types.SabnzbdSummaryResponse) string {
 		"%s:%s:%s:%s:%d|",
 		summary.Queue.Status,
 		summary.Queue.Speed,
-		summary.Queue.NoOfSlots,
+		string(summary.Queue.NoOfSlots),
 		summary.Queue.HaveWarnings,
 		summary.FailedCount,
 	)

--- a/internal/api/handlers/service_payload_builders.go
+++ b/internal/api/handlers/service_payload_builders.go
@@ -454,8 +454,8 @@ func buildSabnzbdSummaryServiceUpdate(instanceID string, summary *types.SabnzbdS
 		summary.RecentFailures = []types.SabnzbdHistorySlot{}
 	}
 
-	queueCount := parseSummaryCount(summary.Queue.NoOfSlots)
-	totalQueueCount := parseSummaryCount(summary.Queue.NoOfSlotsTotal)
+	queueCount := parseSummaryCount(string(summary.Queue.NoOfSlots))
+	totalQueueCount := parseSummaryCount(string(summary.Queue.NoOfSlotsTotal))
 	if totalQueueCount <= 0 {
 		totalQueueCount = queueCount
 	}

--- a/internal/types/flexstring.go
+++ b/internal/types/flexstring.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package types
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// FlexString unmarshals from either a JSON string or a JSON number and stores
+// the value as a string, always marshalling back out as a string.
+//
+// SABnzbd changed several queue fields (e.g. noofslots, noofslots_total) from
+// JSON strings to JSON numbers in newer releases; dashbrr and its web frontend
+// still treat them as strings. This type keeps the upstream parse working while
+// preserving the string contract the frontend expects.
+type FlexString string
+
+func (f *FlexString) UnmarshalJSON(b []byte) error {
+	b = bytes.TrimSpace(b)
+	if len(b) == 0 || string(b) == "null" {
+		*f = ""
+		return nil
+	}
+	if b[0] == '"' {
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+		*f = FlexString(s)
+		return nil
+	}
+	// JSON number (int or float) -> canonical string form
+	var n json.Number
+	if err := json.Unmarshal(b, &n); err != nil {
+		return err
+	}
+	*f = FlexString(n)
+	return nil
+}
+
+func (f FlexString) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(f))
+}

--- a/internal/types/flexstring_test.go
+++ b/internal/types/flexstring_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package types
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestFlexStringUnmarshal(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  FlexString
+	}{
+		{"quoted string", `"42"`, "42"},
+		{"bare integer", `42`, "42"},
+		{"bare float", `4.5`, "4.5"},
+		{"empty string", `""`, ""},
+		{"null", `null`, ""},
+		{"text string", `"queued"`, "queued"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got FlexString
+			if err := json.Unmarshal([]byte(tt.input), &got); err != nil {
+				t.Fatalf("Unmarshal(%s) error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("Unmarshal(%s) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+
+	var f FlexString
+	if err := json.Unmarshal([]byte(`{"not":"a scalar"}`), &f); err == nil {
+		t.Error("Unmarshal(object) expected error, got nil")
+	}
+}
+
+func TestFlexStringMarshal(t *testing.T) {
+	// Always marshals back as a JSON string, preserving the frontend contract.
+	b, err := json.Marshal(FlexString("42"))
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+	if string(b) != `"42"` {
+		t.Errorf("Marshal = %s, want %q", b, `"42"`)
+	}
+}
+
+func TestFlexStringQueueRoundTrip(t *testing.T) {
+	// SABnzbd >=4.5.5 sends these as bare numbers; older versions as strings.
+	type queue struct {
+		NoOfSlots      FlexString `json:"noofslots"`
+		NoOfSlotsTotal FlexString `json:"noofslots_total"`
+	}
+	for _, input := range []string{
+		`{"noofslots":3,"noofslots_total":7}`,
+		`{"noofslots":"3","noofslots_total":"7"}`,
+	} {
+		var q queue
+		if err := json.Unmarshal([]byte(input), &q); err != nil {
+			t.Fatalf("Unmarshal(%s) error: %v", input, err)
+		}
+		if q.NoOfSlots != "3" || q.NoOfSlotsTotal != "7" {
+			t.Errorf("Unmarshal(%s) = %+v, want 3/7", input, q)
+		}
+		out, err := json.Marshal(q)
+		if err != nil {
+			t.Fatalf("Marshal error: %v", err)
+		}
+		if string(out) != `{"noofslots":"3","noofslots_total":"7"}` {
+			t.Errorf("Marshal = %s, want string-typed fields", out)
+		}
+	}
+}

--- a/internal/types/sabnzbd.go
+++ b/internal/types/sabnzbd.go
@@ -22,8 +22,8 @@ type SabnzbdQueue struct {
 	Size            string             `json:"size"`
 	MBLeft          string             `json:"mbleft"`
 	MB              string             `json:"mb"`
-	NoOfSlots       string             `json:"noofslots"`
-	NoOfSlotsTotal  string             `json:"noofslots_total"`
+	NoOfSlots       FlexString         `json:"noofslots"`
+	NoOfSlotsTotal  FlexString         `json:"noofslots_total"`
 	Diskspace1      string             `json:"diskspace1"`
 	Diskspace2      string             `json:"diskspace2"`
 	DiskspaceTotal1 string             `json:"diskspacetotal1"`


### PR DESCRIPTION
Fixes #90

Newer SABnzbd releases return `noofslots` and `noofslots_total` in the `/api?mode=queue` response as JSON numbers rather than strings, which breaks the queue/health poll:

```
json: cannot unmarshal number into Go struct field SabnzbdQueue.queue.noofslots_total of type string
```

This adds a `FlexString` type that unmarshals from either a JSON string or a JSON number and always marshals back as a string, preserving the contract the web frontend (`web/src/types/service.ts`) expects. The two `SabnzbdQueue` fields are retyped to `FlexString`, with `string(...)` casts at the four handler call sites. `SabnzbdHistory.noofslots` is already `int` and is left unchanged.

Running in production against SABnzbd 4.x — the unmarshal errors are gone and the SABnzbd tile polls normally.