### PR TITLE
fix(oidc): do not 401 UI preferences for OIDC sessions without a local user

### DIFF
--- a/internal/api/handlers/ui_preferences.go
+++ b/internal/api/handlers/ui_preferences.go
@@ -83,6 +83,13 @@ func (h *UIPreferencesHandler) UpsertCollapsePreference(c *gin.Context) {
 func getContextUserID(c *gin.Context) (int64, bool) {
 	value, exists := c.Get("user_id")
 	if !exists {
+		// OIDC sessions have no local DB user; RequireAuth has already
+		// validated the session, so treat them as a shared user (0)
+		// instead of failing with a 401 the frontend mistakes for an
+		// expired session (login loop).
+		if authType, ok := c.Get("auth_type"); ok && authType == "oidc" {
+			return 0, true
+		}
 		return 0, false
 	}
 


### PR DESCRIPTION
Fixes #86

With OIDC as the only auth method, logging in produces an infinite login loop: the OIDC callback succeeds and the session is valid, but on dashboard load `GET /api/ui/preferences/collapse` returns `401 {"error":"User context not found"}`. The frontend (`web/src/utils/api.ts`) treats any API 401 as an expired session and redirects to `/login`, so the user bounces login → dashboard → 401 → login forever.

Root cause: OIDC sessions carry no local DB user id, so `attachAuthContext` never sets `user_id` and `getContextUserID` fails — even though the route is already behind `RequireAuth` and the session is fully validated.

Fix: treat authenticated OIDC sessions as a shared user (id 0) in `getContextUserID` instead of failing. UI collapse preferences are then shared across OIDC logins, which matches the information actually available (the session stores no user identity).

Repro: configure `OIDC_*` env vars (tested against authentik), log in, watch the dashboard flash and return to the login page; `/api/ui/preferences/collapse` is the 401 in the network tab. Verified fixed in production.