### PR TITLE
ci: pin pnpm via packageManager instead of corepack@latest

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,9 +23,9 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v6.0.9
         with:
-          version: latest
+          package_json_file: web/package.json
 
       - name: Install frontend dependencies
         working-directory: web

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ on:
 env:
   REGISTRY: ghcr.io
   REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
-  NODE_VERSION: "22.12.0"
+  NODE_VERSION: "22.18.0"
 
 permissions:
   contents: write
@@ -48,10 +48,12 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Set up corepack
-        run: npm install -g corepack@latest && corepack enable
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6.0.9
+        with:
+          package_json_file: web/package.json
 
-      # It can not be done before enable corepack
+      # It can not be done before installing pnpm
       - name: Set up cache
         uses: actions/setup-node@v6
         with:
@@ -86,10 +88,12 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - name: Set up corepack
-        run: npm install -g corepack@latest && corepack enable
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6.0.9
+        with:
+          package_json_file: web/package.json
 
-      # It can not be done before enable corepack
+      # It can not be done before installing pnpm
       - name: Set up cache
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Problem

The `Build web` and `Browser regression` jobs have been failing on `develop` since [2026-07-10](https://github.com/autobrr/dashbrr/actions/runs/29110018657), and consequently on every PR opened since:

```
[command]/opt/hostedtoolcache/node/22.12.0/x64/bin/pnpm store path --silent
! Corepack is about to download .../pnpm-11.14.0.tgz
ERROR: This version of pnpm requires at least Node.js v22.13
The current version of Node.js is v22.12.0
```

Each web job in `release.yml` installed `corepack@latest`, then let the `actions/setup-node` cache step run `pnpm store path` — which executes from the **repository root**. There is no root `package.json`, so corepack had no `packageManager` field to honor (the pin lives in `web/package.json`) and resolved pnpm to its floating latest. pnpm 11 raised its Node floor to 22.13, so with `NODE_VERSION` pinned at 22.12.0 the shim refused to run and the jobs died before installing anything.

This was latent from the day the workflow was written; it only went off when pnpm 11 shipped.

`lint.yml` had a quieter variant of the same bug: `pnpm/action-setup` with `version: latest` installed pnpm 11 and used it to install against a lockfile written by pnpm 10. It stayed green only because its Node is 22.18.0, above pnpm 11's floor.

## Changes

- **`release.yml`** — both web jobs: replace `npm install -g corepack@latest && corepack enable` with `pnpm/action-setup@v6.0.9` and `package_json_file: web/package.json`. The pinned `pnpm@10.4.0` is now on `PATH` before anything calls `pnpm`, so the root-level `pnpm store path` resolves to it regardless of working directory.
- **`lint.yml`** — same pin, replacing `version: latest`.
- **`release.yml`** — `NODE_VERSION` 22.12.0 → 22.18.0, matching `lint.yml`. Not required for the fix now that pnpm is pinned; happy to drop this hunk if you'd rather keep it separate.

This mirrors how `autobrr/autobrr` and `autobrr/qui` set up their web jobs — both use `pnpm/action-setup` with `package_json_file: web/package.json` and neither touches corepack. autobrr's `release.yml` is otherwise structurally identical to this one, down to the comment above the cache step.

## Verification

Locally on Node 22.22, in `web/`:

- `corepack pnpm@10.4.0 install --frozen-lockfile` → passes, so the lockfile is genuinely consistent with the pinned version
- `CI= corepack pnpm@10.4.0 run build` → passes

## Notes

- **Not related to #111.** That PR inherits this red base; it should go green once this lands and dependabot rebases. Nothing in the `actions/setup-node` v6→v7 bump was at fault — the identical failure predates it.
- **Node 22 vs 24 left alone.** Both sibling repos are on 24.15.0; dashbrr is on 22 across `lint.yml`, `release.yml`, and `Dockerfile` (`node:22-alpine3.23`). Moving to 24 would mean touching the Dockerfile and likely bumping `packageManager` to pnpm 11 — a real upgrade rather than a CI fix, so it's out of scope here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XVbrHaheXHW2M6XFEP5EpH)_