### PR TITLE
fix(deps): point dependabot at the real manifest dirs, bump react-router and x/net

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
           - "*"
 
   - package-ecosystem: gomod
-    directory: /backend
+    directory: /
     schedule:
       interval: monthly
     groups:
@@ -21,7 +21,7 @@ updates:
           - "*"
 
   - package-ecosystem: npm
-    directory: /
+    directory: /web
     schedule:
       interval: monthly
     groups:

--- a/go.mod
+++ b/go.mod
@@ -105,7 +105,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/arch v0.24.0 // indirect
 	golang.org/x/exp v0.0.0-20260212183809-81e46e3db34a // indirect
-	golang.org/x/net v0.54.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -255,8 +255,8 @@ golang.org/x/exp v0.0.0-20260212183809-81e46e3db34a h1:ovFr6Z0MNmU7nH8VaX5xqw+05
 golang.org/x/exp v0.0.0-20260212183809-81e46e3db34a/go.mod h1:K79w1Vqn7PoiZn+TkNpx3BUWUQksGO3JcVX6qIjytmA=
 golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
 golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
-golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=
-golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
+golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=
 golang.org/x/oauth2 v0.35.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=

--- a/web/package.json
+++ b/web/package.json
@@ -42,7 +42,7 @@
     "react-hot-toast": "^2.6.0",
     "react-icons": "^5.5.0",
     "react-masonry-css": "^1.0.16",
-    "react-router-dom": "^7.13.0",
+    "react-router-dom": "7.18.1",
     "tailwind-lerp-colors": "^1.2.6",
     "vite-plugin-svgr": "^4.5.0"
   },

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -72,8 +72,8 @@ importers:
         specifier: ^1.0.16
         version: 1.0.16(react@19.2.4)
       react-router-dom:
-        specifier: ^7.13.0
-        version: 7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 7.18.1
+        version: 7.18.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwind-lerp-colors:
         specifier: ^1.2.6
         version: 1.2.6(tsx@4.21.0)(yaml@2.6.0)
@@ -3285,15 +3285,15 @@ packages:
       react: '>= 16.3'
       react-dom: '>= 16.3'
 
-  react-router-dom@7.13.0:
-    resolution: {integrity: sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g==}
+  react-router-dom@7.18.1:
+    resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
 
-  react-router@7.13.0:
-    resolution: {integrity: sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==}
+  react-router@7.18.1:
+    resolution: {integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -7069,13 +7069,13 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       react-draggable: 4.5.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  react-router-dom@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  react-router-dom@7.18.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      react-router: 7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react-router: 7.18.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  react-router@7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  react-router@7.18.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       cookie: 1.1.1
       react: 19.2.4


### PR DESCRIPTION
The `gomod` and `npm` entries in `dependabot.yml` pointed at directories that have never existed in this repo — `/backend`, and `/` for npm (manifests are at `/go.mod` and `/web`). Dependabot doesn't error on a missing directory, it just never opens a PR, so version updates for both ecosystems have silently done nothing since the file was written. Only `github-actions` at `/` was correct. Security updates kept working because those come from the dependency graph rather than this file — every Go/npm PR in the history is a `dependabot/go_modules/…` or `dependabot/npm_and_yarn/…` branch, i.e. reactive advisory fixes, with no `dependabot/gomod/…` or `dependabot/npm/…` version update ever.

Also bumps `react-router-dom` 7.13.0 → 7.18.1 and `golang.org/x/net` 0.54.0 → 0.55.0, retiring the advisories that piled up while version updates were dead. `react-router-dom` is pinned exact rather than caret because 7.18.2 is two days old and trips the 7-day minimum release age guardrail; worth restoring the caret once the `pnpm@10.4.0` pin moves past 10.17, which is where `minimum-release-age` support landed. Heads up that the first monthly run after this merges will be a chunky catch-up PR for both ecosystems.

Verified: `go build ./...`, `go test ./...`, `pnpm install --frozen-lockfile`, `pnpm typecheck`, `pnpm build` all pass.