### PR TITLE
chore(web): align eslint config with qui

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -1,15 +1,18 @@
 import js from "@eslint/js";
+import stylistic from "@stylistic/eslint-plugin";
 import globals from "globals";
 import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
-import * as tseslint from "typescript-eslint";
+import { globalIgnores } from "eslint/config";
+import tseslint from "typescript-eslint";
 
-export default tseslint.config(
-  { ignores: ["dist", "dev-dist"] },
-  js.configs.recommended,
-  ...tseslint.configs.recommended,
+export default tseslint.config([
+  globalIgnores(["dist", "dev-dist", "vite.config.ts"]),
   {
+    // dashbrr-only: qui has no equivalent script, and the shared config below
+    // matches .ts/.tsx only, so this would otherwise go unlinted.
     files: ["scripts/**/*.js"],
+    extends: [js.configs.recommended],
     languageOptions: {
       globals: {
         ...globals.node,
@@ -20,34 +23,43 @@ export default tseslint.config(
   },
   {
     files: ["**/*.{ts,tsx}"],
+    extends: [
+      js.configs.recommended,
+      tseslint.configs.recommended,
+      reactRefresh.configs.vite,
+    ],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: {
-        ...globals.browser,
-      },
-      parser: tseslint.parser,
-      parserOptions: {
-        project: [
-          "./tsconfig.app.json",
-          "./tsconfig.node.json",
-          "./tsconfig.tests.json",
-        ],
-      },
+      globals: globals.browser,
     },
     plugins: {
+      "@stylistic": stylistic,
       "react-hooks": reactHooks,
-      "react-refresh": reactRefresh,
     },
     rules: {
-      ...reactHooks.configs.recommended.rules,
-      // v7 adds opinionated rules; keep baseline hook rules, but don't block builds on heuristics.
-      "react-hooks/immutability": "off",
-      "react-hooks/purity": "off",
-      "react-hooks/set-state-in-effect": "off",
-      "react-refresh/only-export-components": [
+      "@stylistic/quotes": ["warn", "double"],
+      "@stylistic/comma-dangle": [
         "warn",
-        { allowConstantExport: true },
+        {
+          arrays: "always-multiline",
+          objects: "always-multiline",
+          imports: "never",
+          exports: "always-multiline",
+          functions: "never",
+        },
       ],
+      "@stylistic/indent": ["error", 2, { "SwitchCase": 1 }],
+      // qui sets multiline-ternary to "never"; omitted here because dashbrr
+      // uses nested multiline ternaries for JSX className logic, and the
+      // autofix collapses those into 300+ char lines.
+      "@stylistic/no-trailing-spaces": ["warn"],
+      "@stylistic/object-curly-spacing": ["error", "always"],
+      "@typescript-eslint/no-unused-vars": ["warn"],
+      "@typescript-eslint/no-explicit-any": "error",
+      "linebreak-style": ["error", "unix"],
+      "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+      "react-hooks/rules-of-hooks": "error",
+      "react-hooks/exhaustive-deps": "warn",
     },
-  }
-);
+  },
+]);

--- a/web/package.json
+++ b/web/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.62.0",
+    "@stylistic/eslint-plugin": "^5.10.0",
     "@tailwindcss/postcss": "^4.3.3",
     "@types/node": "^26.1.2",
     "@types/react": "^19.2.17",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       '@playwright/test':
         specifier: ^1.62.0
         version: 1.62.0
+      '@stylistic/eslint-plugin':
+        specifier: ^5.10.0
+        version: 5.10.0(eslint@10.8.0(jiti@1.21.7))
       '@tailwindcss/postcss':
         specifier: ^4.3.3
         version: 4.3.3
@@ -1624,6 +1627,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@stylistic/eslint-plugin@5.10.0':
+    resolution: {integrity: sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^9.0.0 || ^10.0.0
+
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0':
     resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
     engines: {node: '>=14'}
@@ -2336,6 +2345,10 @@ packages:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   eslint-visitor-keys@5.0.1:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -2349,6 +2362,10 @@ packages:
     peerDependenciesMeta:
       jiti:
         optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   espree@11.2.0:
     resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
@@ -5268,6 +5285,16 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.3':
     optional: true
 
+  '@stylistic/eslint-plugin@5.10.0(eslint@10.8.0(jiti@1.21.7))':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@1.21.7))
+      '@typescript-eslint/types': 8.65.0
+      eslint: 10.8.0(jiti@1.21.7)
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      estraverse: 5.3.0
+      picomatch: 4.0.5
+
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -6124,6 +6151,8 @@ snapshots:
 
   eslint-visitor-keys@3.4.3: {}
 
+  eslint-visitor-keys@4.2.1: {}
+
   eslint-visitor-keys@5.0.1: {}
 
   eslint@10.8.0(jiti@1.21.7):
@@ -6162,6 +6191,12 @@ snapshots:
       jiti: 1.21.7
     transitivePeerDependencies:
       - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.18.0
+      acorn-jsx: 5.3.2(acorn@8.18.0)
+      eslint-visitor-keys: 4.2.1
 
   espree@11.2.0:
     dependencies:

--- a/web/src/components/AddServicesMenu.tsx
+++ b/web/src/components/AddServicesMenu.tsx
@@ -413,7 +413,7 @@ export function AddServicesMenu({
                                 onClick={() =>
                                   onAddService(template.type, template.name)
                                 }
-                                  className={`block w-full px-4 py-2 text-left text-sm ${
+                                className={`block w-full px-4 py-2 text-left text-sm ${
                                   active
                                     ? "bg-zinc-100 dark:bg-zinc-700 text-zinc-900 dark:text-zinc-300"
                                     : "text-zinc-700 dark:text-zinc-300"

--- a/web/src/components/configuration/ConfigurationForm.tsx
+++ b/web/src/components/configuration/ConfigurationForm.tsx
@@ -179,7 +179,7 @@ export const ConfigurationForm = ({
               ? getSettingsUrl("/config/general/")
               : serviceType === "nzbget"
                 ? getSettingsUrl("/#settings")
-              : getSettingsUrl("/settings/general"),
+                : getSettingsUrl("/settings/general"),
         };
       case "jellyfin":
         return {

--- a/web/src/components/services/ServiceCard.tsx
+++ b/web/src/components/services/ServiceCard.tsx
@@ -29,7 +29,7 @@ import { useCollapsiblePreference } from "../../hooks/useCollapsiblePreference";
 import { serviceCardCollapseKey } from "../../utils/collapsePreferences";
 import {
   getServiceCardLayoutClasses,
-  hasMeaningfulServiceContent,
+  hasMeaningfulServiceContent
 } from "../../utils/serviceCardContent";
 
 interface DragHandleProps {

--- a/web/src/components/services/ServiceGrid.tsx
+++ b/web/src/components/services/ServiceGrid.tsx
@@ -15,14 +15,14 @@ import {
   PointerSensor,
   useSensor,
   useSensors,
-  DragEndEvent,
+  DragEndEvent
 } from "@dnd-kit/core";
 import {
   arrayMove,
   SortableContext,
   sortableKeyboardCoordinates,
   rectSortingStrategy,
-  useSortable,
+  useSortable
 } from "@dnd-kit/sortable";
 
 interface ServiceGridProps {
@@ -96,12 +96,12 @@ const DraggableServiceCard = ({
 
   const style: CSSProperties | undefined = transform
     ? {
-        transform: `translate3d(${transform.x}px, ${transform.y}px, 0)`,
-        transition,
-        zIndex: isDragging ? 2 : undefined,
-        position: isDragging ? ("relative" as const) : undefined,
-        opacity: isDragging ? 0.8 : undefined,
-      }
+      transform: `translate3d(${transform.x}px, ${transform.y}px, 0)`,
+      transition,
+      zIndex: isDragging ? 2 : undefined,
+      position: isDragging ? ("relative" as const) : undefined,
+      opacity: isDragging ? 0.8 : undefined,
+    }
     : undefined;
 
   return (

--- a/web/src/components/services/TailscaleDeviceModal.tsx
+++ b/web/src/components/services/TailscaleDeviceModal.tsx
@@ -151,7 +151,7 @@ const TailscaleDeviceModal: React.FC<Props> = ({
                               className="font-medium text-gray-300 hover:text-blue-400 transition-colors text-left inline-flex items-center cursor-pointer group"
                               title={`Click to copy: ${device.name}`}
                             >
-                             <span className="text-base">{device.name}</span>
+                              <span className="text-base">{device.name}</span>
                               <CopyIcon />
                             </button>
                           </div>

--- a/web/src/components/services/autobrr/AutobrrStats.tsx
+++ b/web/src/components/services/autobrr/AutobrrStats.tsx
@@ -15,11 +15,11 @@ import {
   XCircleIcon,
   ExclamationCircleIcon,
   NoSymbolIcon,
-  ClockIcon,
+  ClockIcon
 } from "@heroicons/react/24/outline";
 import {
   AutobrrRelease,
-  AutobrrStats as AutobrrStatsPayload,
+  AutobrrStats as AutobrrStatsPayload
 } from "../../../types/service";
 import { getMediaType, getMediaTypeIcon } from "../../../utils/mediaTypes";
 import { StatsSkeleton } from "../../ui/StatsSkeleton";
@@ -182,114 +182,114 @@ export const AutobrrStats: React.FC<AutobrrStatsProps> = ({ instanceId }) => {
           isExpanded={isExpanded}
           onToggle={toggle}
         >
-            {releases.length > 0 ? (
-              <div className="max-h-80 space-y-2 overflow-y-auto pr-1">
-                {releases.slice(0, 5).map((release: AutobrrRelease) => (
-                  <div
-                    key={release.id}
-                    className="text-xs rounded-md text-gray-600 dark:text-gray-400 bg-gray-850/95 p-3.5 hover:bg-gray-850/70 transition-colors"
-                  >
-                    <div className="flex flex-col gap-2">
-                      <div className="flex items-center gap-2">
-                        {release.filter_status === "FILTER_REJECTED" ? (
-                          <span className="text-red-500">
-                            <NoSymbolIcon className="h-4 w-4" />
-                          </span>
-                        ) : release.action_status?.[0]?.status === "PUSH_APPROVED" ? (
-                          <span className="text-green-500">
-                            <CheckCircleIcon className="h-4 w-4" />
-                          </span>
-                        ) : release.action_status?.[0]?.status === "PUSH_REJECTED" ? (
-                          <span className="text-blue-400">
-                            <XCircleIcon className="h-4 w-4" />
-                          </span>
-                        ) : release.action_status?.[0]?.status === "PUSH_ERROR" ? (
-                          <span className="text-red-500">
-                            <ExclamationCircleIcon className="h-4 w-4" />
-                          </span>
-                        ) : (
-                          <span className="text-yellow-500">
-                            <ClockIcon className="h-4 w-4" />
-                          </span>
-                        )}
-                        <span className="text-xs font-medium text-gray-200 truncate flex-1" title={release.name}>
-                          {release.name}
+          {releases.length > 0 ? (
+            <div className="max-h-80 space-y-2 overflow-y-auto pr-1">
+              {releases.slice(0, 5).map((release: AutobrrRelease) => (
+                <div
+                  key={release.id}
+                  className="text-xs rounded-md text-gray-600 dark:text-gray-400 bg-gray-850/95 p-3.5 hover:bg-gray-850/70 transition-colors"
+                >
+                  <div className="flex flex-col gap-2">
+                    <div className="flex items-center gap-2">
+                      {release.filter_status === "FILTER_REJECTED" ? (
+                        <span className="text-red-500">
+                          <NoSymbolIcon className="h-4 w-4" />
                         </span>
-                        <div className="flex items-center gap-1 flex-shrink-0">
-                          {release.download_url && (
-                            <a
-                              href={release.download_url}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="text-blue-400 hover:text-blue-300 p-1 hover:bg-gray-700/50 rounded transition-colors"
-                              title={`Download torrentfile`}
-                            >
-                              <ArrowDownTrayIcon className="h-3.5 w-3.5" />
-                            </a>
-                          )}
-                          {release.info_url && (
-                            <a
-                              href={release.info_url}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="text-blue-400 hover:text-blue-300 p-1 hover:bg-gray-700/50 rounded transition-colors"
-                              title={`View this release on ${release.indexer.name}`}
-                            >
-                              <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5" />
-                            </a>
-                          )}
-                        </div>
-                      </div>
-                      <div className="flex flex-wrap items-center justify-between gap-y-1 text-xs text-gray-400">
-                        <div className="flex flex-wrap items-center gap-x-2">
-                          {release.source && (
-                            <span className="flex items-center gap-1 bg-gray-800/50 py-0.5 rounded">
-                              {(() => {
-                                const mediaType = getMediaType(release.category);
-                                const IconComponent = getMediaTypeIcon(mediaType);
-                                return (
-                                  <>
-                                    <IconComponent className="h-4 w-4 text-gray-400" />
-                                    {mediaType}
-                                  </>
-                                );
-                              })()}
-                            </span>
-                          )}
-                          <span className="flex items-center gap-1 bg-gray-800/50 px-1.5 py-0.5 rounded">
-                            {release.indexer.name}
-                          </span>
-                          {release.filter && (
-                            <span className="bg-gray-800/50 px-1.5 py-0.5 rounded">
-                              {release.filter}
-                            </span>
-                          )}
-                        </div>
-                        {release.action_status?.[0]?.status && (
-                          <span className={`bg-gray-800/50 px-1.5 py-0.5 rounded ${
-                            release.action_status[0].status === "PUSH_APPROVED"
-                              ? "text-green-500"
-                              : release.action_status[0].status === "PUSH_REJECTED"
-                              ? "text-blue-400"
-                              : release.action_status[0].status === "PUSH_ERROR"
-                              ? "text-red-500"
-                              : "text-yellow-500"
-                          }`}>
-                            {release.action_status[0].status.replace("PUSH_", "")
-                              .toLowerCase()
-                              .replace(/^\w/, (c) => c.toUpperCase())}
-                          </span>
+                      ) : release.action_status?.[0]?.status === "PUSH_APPROVED" ? (
+                        <span className="text-green-500">
+                          <CheckCircleIcon className="h-4 w-4" />
+                        </span>
+                      ) : release.action_status?.[0]?.status === "PUSH_REJECTED" ? (
+                        <span className="text-blue-400">
+                          <XCircleIcon className="h-4 w-4" />
+                        </span>
+                      ) : release.action_status?.[0]?.status === "PUSH_ERROR" ? (
+                        <span className="text-red-500">
+                          <ExclamationCircleIcon className="h-4 w-4" />
+                        </span>
+                      ) : (
+                        <span className="text-yellow-500">
+                          <ClockIcon className="h-4 w-4" />
+                        </span>
+                      )}
+                      <span className="text-xs font-medium text-gray-200 truncate flex-1" title={release.name}>
+                        {release.name}
+                      </span>
+                      <div className="flex items-center gap-1 flex-shrink-0">
+                        {release.download_url && (
+                          <a
+                            href={release.download_url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-blue-400 hover:text-blue-300 p-1 hover:bg-gray-700/50 rounded transition-colors"
+                            title={"Download torrentfile"}
+                          >
+                            <ArrowDownTrayIcon className="h-3.5 w-3.5" />
+                          </a>
+                        )}
+                        {release.info_url && (
+                          <a
+                            href={release.info_url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-blue-400 hover:text-blue-300 p-1 hover:bg-gray-700/50 rounded transition-colors"
+                            title={`View this release on ${release.indexer.name}`}
+                          >
+                            <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5" />
+                          </a>
                         )}
                       </div>
                     </div>
+                    <div className="flex flex-wrap items-center justify-between gap-y-1 text-xs text-gray-400">
+                      <div className="flex flex-wrap items-center gap-x-2">
+                        {release.source && (
+                          <span className="flex items-center gap-1 bg-gray-800/50 py-0.5 rounded">
+                            {(() => {
+                              const mediaType = getMediaType(release.category);
+                              const IconComponent = getMediaTypeIcon(mediaType);
+                              return (
+                                <>
+                                  <IconComponent className="h-4 w-4 text-gray-400" />
+                                  {mediaType}
+                                </>
+                              );
+                            })()}
+                          </span>
+                        )}
+                        <span className="flex items-center gap-1 bg-gray-800/50 px-1.5 py-0.5 rounded">
+                          {release.indexer.name}
+                        </span>
+                        {release.filter && (
+                          <span className="bg-gray-800/50 px-1.5 py-0.5 rounded">
+                            {release.filter}
+                          </span>
+                        )}
+                      </div>
+                      {release.action_status?.[0]?.status && (
+                        <span className={`bg-gray-800/50 px-1.5 py-0.5 rounded ${
+                          release.action_status[0].status === "PUSH_APPROVED"
+                            ? "text-green-500"
+                            : release.action_status[0].status === "PUSH_REJECTED"
+                              ? "text-blue-400"
+                              : release.action_status[0].status === "PUSH_ERROR"
+                                ? "text-red-500"
+                                : "text-yellow-500"
+                        }`}>
+                          {release.action_status[0].status.replace("PUSH_", "")
+                            .toLowerCase()
+                            .replace(/^\w/, (c) => c.toUpperCase())}
+                        </span>
+                      )}
+                    </div>
                   </div>
-                ))}
-              </div>
-            ) : (
-              <div className="text-xs rounded-md text-gray-600 dark:text-gray-400 bg-gray-850/95 p-3.5">
-                No recent releases
-              </div>
-            )}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="text-xs rounded-md text-gray-600 dark:text-gray-400 bg-gray-850/95 p-3.5">
+              No recent releases
+            </div>
+          )}
         </CollapsibleSection>
       )}
     </div>

--- a/web/src/components/services/common/ArrMessage.tsx
+++ b/web/src/components/services/common/ArrMessage.tsx
@@ -6,7 +6,7 @@
 import React from "react";
 import {
   ExclamationTriangleIcon,
-  CheckCircleIcon,
+  CheckCircleIcon
 } from "@heroicons/react/24/outline";
 import { ServiceStatus } from "../../../types/service";
 

--- a/web/src/components/services/common/ArrQueueStatsBase.tsx
+++ b/web/src/components/services/common/ArrQueueStatsBase.tsx
@@ -8,7 +8,7 @@ import { Listbox, Transition } from "@headlessui/react";
 import {
   ArrowTopRightOnSquareIcon,
   ChevronDownIcon,
-  Cog6ToothIcon,
+  Cog6ToothIcon
 } from "@heroicons/react/24/solid";
 import { toast } from "react-hot-toast";
 
@@ -25,7 +25,7 @@ import {
   ArrQueueDeleteOptions,
   buildArrQueueDeleteQueryParams,
   getBlocklistText,
-  getRemovalMethodText,
+  getRemovalMethodText
 } from "./ArrQueueDelete";
 
 export type ArrQueueRecord = {

--- a/web/src/components/services/common/playbackUi.tsx
+++ b/web/src/components/services/common/playbackUi.tsx
@@ -13,7 +13,7 @@ import {
   FaPlay,
   FaPlayCircle,
   FaTablet,
-  FaTv,
+  FaTv
 } from "react-icons/fa";
 
 export const formatDurationMs = (durationMs: number): string => {

--- a/web/src/components/services/jellyfin/JellyfinStats.tsx
+++ b/web/src/components/services/jellyfin/JellyfinStats.tsx
@@ -16,14 +16,14 @@ import { serviceSectionCollapseKey } from "../../../utils/collapsePreferences";
 import type {
   JellyfinMediaStream,
   JellyfinSession,
-  JellyfinSummary,
+  JellyfinSummary
 } from "../../../types/service";
 import {
   formatBitrateBps,
   formatDurationTicks,
   getDeviceIcon,
   getMediaTypeIcon,
-  getProgressPercentage,
+  getProgressPercentage
 } from "../common/playbackUi";
 
 interface JellyfinStatsProps {

--- a/web/src/components/services/maintainerr/MaintainerrService.tsx
+++ b/web/src/components/services/maintainerr/MaintainerrService.tsx
@@ -10,7 +10,7 @@ import { MaintainerrMessage } from "./MaintainerrMessage";
 import {
   ExclamationTriangleIcon,
   CheckCircleIcon,
-  XCircleIcon,
+  XCircleIcon
 } from "@heroicons/react/24/outline";
 
 interface MaintainerrServiceProps {

--- a/web/src/components/services/overseerr/OverseerrRequestModal.tsx
+++ b/web/src/components/services/overseerr/OverseerrRequestModal.tsx
@@ -10,7 +10,7 @@ import { FaFilm, FaTv } from "react-icons/fa";
 import {
   ClockIcon,
   UserIcon,
-  ArrowTopRightOnSquareIcon,
+  ArrowTopRightOnSquareIcon
 } from "@heroicons/react/24/outline";
 
 interface OverseerrRequestModalProps {
@@ -76,7 +76,7 @@ export const OverseerrRequestModal: React.FC<OverseerrRequestModalProps> = ({
                 <div>
                   <div className="flex items-center gap-3">
                     <div
-                      className={`p-2 rounded-lg bg-gray-700/50 border border-gray-600/50 shadow-inner h-fit`}
+                      className={"p-2 rounded-lg bg-gray-700/50 border border-gray-600/50 shadow-inner h-fit"}
                     >
                       {request.media.tvdbId ? (
                         <FaTv className="h-5 w-5 text-blue-400" />

--- a/web/src/components/services/overseerr/OverseerrStats.tsx
+++ b/web/src/components/services/overseerr/OverseerrStats.tsx
@@ -11,7 +11,7 @@ import { OverseerrRequestModal } from "./OverseerrRequestModal";
 import {
   CheckCircleIcon,
   XCircleIcon,
-  ClockIcon,
+  ClockIcon
 } from "@heroicons/react/24/outline";
 import { api } from "../../../utils/api";
 import { toast } from "react-hot-toast";
@@ -25,7 +25,7 @@ import { serviceSectionCollapseKey } from "../../../utils/collapsePreferences";
 import {
   getRequestStatus,
   OVERSEERR_REQUEST_STATUS,
-  resolveRequestStatus,
+  resolveRequestStatus
 } from "./status";
 
 interface OverseerrStatsProps {
@@ -350,13 +350,13 @@ export const OverseerrStats: React.FC<OverseerrStatsProps> = ({
           isExpanded={isExpanded}
           onToggle={toggle}
         >
-            <div className="max-h-80 space-y-2 overflow-y-auto pr-1">
-              {recentNonPendingRequests
-                .slice(0, 5)
-                .map((request) => (
-                  <RequestItem key={request.id} request={request} />
-                ))}
-            </div>
+          <div className="max-h-80 space-y-2 overflow-y-auto pr-1">
+            {recentNonPendingRequests
+              .slice(0, 5)
+              .map((request) => (
+                <RequestItem key={request.id} request={request} />
+              ))}
+          </div>
         </CollapsibleSection>
       ) : (
         <div className="text-xs rounded-md text-gray-600 dark:text-gray-400 bg-gray-850/95 p-4">

--- a/web/src/components/services/plex/PlexStats.tsx
+++ b/web/src/components/services/plex/PlexStats.tsx
@@ -18,7 +18,7 @@ import {
   formatDurationMs,
   getDeviceIcon,
   getMediaTypeIcon,
-  getProgressPercentage,
+  getProgressPercentage
 } from "../common/playbackUi";
 
 interface PlexStatsProps {
@@ -210,8 +210,8 @@ export const PlexStats: React.FC<PlexStatsProps> = ({ instanceId }) => {
                               ? `${session.grandparentTitle} - ${session.title}`
                               : session.title
                             : session.grandparentTitle
-                            ? `${session.grandparentTitle} - ${session.title}`
-                            : session.title ?? ""} 
+                              ? `${session.grandparentTitle} - ${session.title}`
+                              : session.title ?? ""}
                           {session.type?.toLowerCase() === "clip" && (
                             <span className="text-purple-400 ml-1">(Trailer)</span>
                           )}

--- a/web/src/components/services/prowlarr/ProwlarrStats.tsx
+++ b/web/src/components/services/prowlarr/ProwlarrStats.tsx
@@ -15,7 +15,7 @@ import { CollapsibleSection } from "../../ui/CollapsibleSection";
 import {
   ClockIcon,
   ArrowDownTrayIcon,
-  MagnifyingGlassIcon,
+  MagnifyingGlassIcon
 } from "@heroicons/react/24/outline";
 
 interface ProwlarrStatsProps {
@@ -116,14 +116,14 @@ export const ProwlarrStats: React.FC<ProwlarrStatsProps> = ({ instanceId }) => {
                         indexer.priority === 1
                           ? "bg-green-500/10 text-green-400/80"
                           : indexer.priority <= 3
-                          ? "bg-blue-500/10 text-blue-400/80"
-                          : indexer.priority <= 5
-                          ? "bg-indigo-500/10 text-indigo-400/80"
-                          : indexer.priority <= 7
-                          ? "bg-purple-500/10 text-purple-400/80"
-                          : indexer.priority <= 10
-                          ? "bg-yellow-500/10 text-yellow-400/80"
-                          : "bg-red-500/10 text-red-400/80"
+                            ? "bg-blue-500/10 text-blue-400/80"
+                            : indexer.priority <= 5
+                              ? "bg-indigo-500/10 text-indigo-400/80"
+                              : indexer.priority <= 7
+                                ? "bg-purple-500/10 text-purple-400/80"
+                                : indexer.priority <= 10
+                                  ? "bg-yellow-500/10 text-yellow-400/80"
+                                  : "bg-red-500/10 text-red-400/80"
                       }`}
                     >
                       P{indexer.priority}

--- a/web/src/components/services/uptimekuma/UptimeKumaStats.tsx
+++ b/web/src/components/services/uptimekuma/UptimeKumaStats.tsx
@@ -147,8 +147,8 @@ export const UptimeKumaStats: React.FC<UptimeKumaStatsProps> = ({ instanceId }) 
                   <span className="truncate">{monitor.type || "monitor"}</span>
                   {typeof monitor.responseTimeMs === "number" &&
                     monitor.responseTimeMs > 0 && (
-                      <span>{monitor.responseTimeMs}ms</span>
-                    )}
+                    <span>{monitor.responseTimeMs}ms</span>
+                  )}
                 </div>
               </div>
             ))}

--- a/web/src/components/shared/LoadingState.tsx
+++ b/web/src/components/shared/LoadingState.tsx
@@ -86,10 +86,10 @@ export const LoadingState: React.FC<LoadingStateProps> = ({
               animate-ping
               opacity-20
               ${
-                variant === "primary"
-                  ? "bg-blue-500"
-                  : "bg-gray-400 dark:bg-gray-600"
-              }
+    variant === "primary"
+      ? "bg-blue-500"
+      : "bg-gray-400 dark:bg-gray-600"
+    }
             `}
           />
         </div>

--- a/web/src/components/ui/ServiceHeader.tsx
+++ b/web/src/components/ui/ServiceHeader.tsx
@@ -7,7 +7,7 @@ import React, { useState } from "react";
 import {
   ArrowTopRightOnSquareIcon,
   Cog6ToothIcon,
-  TrashIcon,
+  TrashIcon
 } from "@heroicons/react/20/solid";
 import AnimatedModal from "./AnimatedModal";
 import { StatusIcon, StatusType } from "./StatusIcon";

--- a/web/src/components/ui/StatusIndicator.tsx
+++ b/web/src/components/ui/StatusIndicator.tsx
@@ -119,18 +119,18 @@ export const StatusIndicator: React.FC<StatusIndicatorProps> = ({
   const statusDisplay: StatusDisplay = isInitialLoad
     ? { text: "Loading", color: "text-blue-500 dark:text-blue-400", icon: "⟳" }
     : !isConnected
-    ? {
+      ? {
         text: "Disconnected",
         color: "text-amber-500 dark:text-amber-300",
         icon: "⚠",
       }
-    : STATUS_DISPLAY_MAP[status] || UNKNOWN_STATUS_DISPLAY;
+      : STATUS_DISPLAY_MAP[status] || UNKNOWN_STATUS_DISPLAY;
   const shouldShowMessage = message && (status !== "online" || !isConnected);
   const displayMessage = isInitialLoad
     ? "Initializing service..."
     : !isConnected
-    ? "Connection to server lost"
-    : message || "";
+      ? "Connection to server lost"
+      : message || "";
 
   const formatMessage = (msg: string) => {
     const sections: Record<string, React.ReactNode[]> = {};

--- a/web/src/config/auth.ts
+++ b/web/src/config/auth.ts
@@ -11,24 +11,24 @@ const getFrontendUrl = () => {
 
 // Common auth endpoints
 const COMMON_ENDPOINTS = {
-  config: '/api/auth/config',
-  userInfo: '/api/auth/userinfo',
+  config: "/api/auth/config",
+  userInfo: "/api/auth/userinfo",
 };
 
 // OIDC-specific endpoints
 const OIDC_ENDPOINTS = {
   login: `/api/auth/oidc/login?frontendUrl=${encodeURIComponent(getFrontendUrl())}`,
   logout: `/api/auth/oidc/logout?frontendUrl=${encodeURIComponent(getFrontendUrl())}`,
-  verify: '/api/auth/oidc/verify',
-  userInfo: '/api/auth/oidc/userinfo',
+  verify: "/api/auth/oidc/verify",
+  userInfo: "/api/auth/oidc/userinfo",
 };
 
 // Built-in auth endpoints
 const BUILTIN_ENDPOINTS = {
-  login: '/api/auth/login',
-  register: '/api/auth/register',
-  logout: '/api/auth/logout',
-  verify: '/api/auth/verify',
+  login: "/api/auth/login",
+  register: "/api/auth/register",
+  logout: "/api/auth/logout",
+  verify: "/api/auth/verify",
 };
 
 export const AUTH_URLS = {
@@ -42,7 +42,7 @@ export interface AuthConfig {
     builtin: boolean;
     oidc: boolean;
   };
-  default: 'builtin' | 'oidc';
+  default: "builtin" | "oidc";
   bypass?: boolean;
 }
 
@@ -50,18 +50,18 @@ export async function getAuthConfig(): Promise<AuthConfig> {
   try {
     const response = await fetch(AUTH_URLS.config);
     if (!response.ok) {
-      throw new Error('Failed to fetch auth configuration');
+      throw new Error("Failed to fetch auth configuration");
     }
     return await response.json();
   } catch (error) {
-    console.error('Error fetching auth config:', error);
+    console.error("Error fetching auth config:", error);
     // Return default configuration if fetch fails
     return {
       methods: {
         builtin: true,
         oidc: false,
       },
-      default: 'builtin',
+      default: "builtin",
       bypass: false,
     };
   }

--- a/web/src/config/serviceTemplates.ts
+++ b/web/src/config/serviceTemplates.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { Service } from '../types/service';
+import { Service } from "../types/service";
 
 export const serviceTemplates: Omit<Service, "id" | "instanceId">[] = [
   {

--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -9,7 +9,7 @@ import {
   AuthContextType,
   User,
   LoginCredentials,
-  RegisterCredentials,
+  RegisterCredentials
 } from "../types/auth";
 import { AUTH_URLS, getAuthConfig, AuthConfig } from "../config/auth";
 import { readErrorMessage } from "../utils/http";

--- a/web/src/contexts/useConfiguration.ts
+++ b/web/src/contexts/useConfiguration.ts
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useContext } from 'react';
-import { ConfigurationContext } from './context';
+import { useContext } from "react";
+import { ConfigurationContext } from "./context";
 
 export const useConfiguration = () => {
   const context = useContext(ConfigurationContext);
   if (!context) {
-    throw new Error('useConfiguration must be used within a ConfigurationProvider');
+    throw new Error("useConfiguration must be used within a ConfigurationProvider");
   }
 
   return {

--- a/web/src/hooks/serviceData/merge.ts
+++ b/web/src/hooks/serviceData/merge.ts
@@ -8,7 +8,7 @@ import {
   ServiceConfig,
   ServiceHealth,
   ServiceStatus,
-  ServiceType,
+  ServiceType
 } from "../../types/service";
 import { serviceTemplates } from "../../config/serviceTemplates";
 
@@ -218,10 +218,10 @@ export const deriveHealthUpdate = (
   payload: unknown
 ):
   | {
-      instanceId: string;
-      patch: Partial<Service>;
-      internalStatus?: ServiceStatus;
-    }
+    instanceId: string;
+    patch: Partial<Service>;
+    internalStatus?: ServiceStatus;
+  }
   | undefined => {
   if (typeof payload !== "object" || payload === null) {
     return undefined;
@@ -268,17 +268,17 @@ export const hydrateServicesFromConfigurations = (
     const existing = next.get(instanceId);
     let merged = existing
       ? {
-          ...existing,
-          id: base.id,
-          instanceId: base.instanceId,
-          name: base.name,
-          type: base.type,
-          url: base.url,
-          accessUrl: base.accessUrl,
-          apiKey: base.apiKey,
-          displayName: base.displayName,
-          healthEndpoint: base.healthEndpoint,
-        }
+        ...existing,
+        id: base.id,
+        instanceId: base.instanceId,
+        name: base.name,
+        type: base.type,
+        url: base.url,
+        accessUrl: base.accessUrl,
+        apiKey: base.apiKey,
+        displayName: base.displayName,
+        healthEndpoint: base.healthEndpoint,
+      }
       : base;
 
     const snapshot = latestPatchByInstance.get(instanceId);

--- a/web/src/hooks/serviceData/reducer.ts
+++ b/web/src/hooks/serviceData/reducer.ts
@@ -6,7 +6,7 @@
 import { Service, ServiceConfig, ServiceStatus } from "../../types/service";
 import {
   applyServicePatch,
-  hydrateServicesFromConfigurations,
+  hydrateServicesFromConfigurations
 } from "./merge";
 import type { ServicePatchSnapshot } from "./merge";
 
@@ -19,16 +19,16 @@ export type ServiceDataAction =
   | { type: "set_loading"; isLoading: boolean }
   | { type: "reset" }
   | {
-      type: "hydrate_configurations";
-      configurations: Record<string, ServiceConfig>;
-      latestPatchByInstance: Map<string, ServicePatchSnapshot>;
-    }
+    type: "hydrate_configurations";
+    configurations: Record<string, ServiceConfig>;
+    latestPatchByInstance: Map<string, ServicePatchSnapshot>;
+  }
   | {
-      type: "apply_patch";
-      instanceId: string;
-      patch: Partial<Service>;
-      internalStatus?: ServiceStatus;
-    };
+    type: "apply_patch";
+    instanceId: string;
+    patch: Partial<Service>;
+    internalStatus?: ServiceStatus;
+  };
 
 export const initialServiceDataState: ServiceDataState = {
   services: new Map(),

--- a/web/src/hooks/useAuth.ts
+++ b/web/src/hooks/useAuth.ts
@@ -7,4 +7,4 @@ export function useAuth() {
     throw new Error("useAuth must be used within an AuthProvider");
   }
   return context;
-} 
+}

--- a/web/src/hooks/useServiceData.ts
+++ b/web/src/hooks/useServiceData.ts
@@ -12,19 +12,19 @@ import {
   useEffect,
   useMemo,
   useRef,
-  useReducer,
+  useReducer
 } from "react";
 import { Service } from "../types/service";
 import { useConfiguration } from "../contexts/useConfiguration";
 import { useAuth } from "./useAuth";
 import {
   deriveHealthUpdate,
-  mergeServicePatchSnapshot,
+  mergeServicePatchSnapshot
 } from "./serviceData/merge";
 import type { ServicePatchSnapshot } from "./serviceData/merge";
 import {
   initialServiceDataState,
-  serviceDataReducer,
+  serviceDataReducer
 } from "./serviceData/reducer";
 
 type ServiceDataContextValue = {

--- a/web/src/hooks/useServiceHealth.ts
+++ b/web/src/hooks/useServiceHealth.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useMemo } from 'react';
-import { useServiceData } from './useServiceData';
-import { ServiceStatus } from '../types/service';
+import { useMemo } from "react";
+import { useServiceData } from "./useServiceData";
+import { ServiceStatus } from "../types/service";
 
 type StatusCount = Record<ServiceStatus, number>;
 
@@ -25,7 +25,7 @@ export const useServiceHealth = () => {
   // Memoize status counts to prevent unnecessary recalculations
   const statusCounts = useMemo((): StatusCount => {
     return (services || []).reduce((acc, service) => {
-      const status = service.status || 'unknown';
+      const status = service.status || "unknown";
       acc[status] += 1;
       return acc;
     }, { ...initialStatusCount });

--- a/web/src/hooks/useServiceManagement.ts
+++ b/web/src/hooks/useServiceManagement.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import { useCallback, useState } from 'react';
-import { ServiceType } from '../types/service';
-import { useConfiguration } from '../contexts/useConfiguration';
-import { toast } from 'react-hot-toast';
+import { useCallback, useState } from "react";
+import { ServiceType } from "../types/service";
+import { useConfiguration } from "../contexts/useConfiguration";
+import { toast } from "react-hot-toast";
 
 interface PendingService {
   type: ServiceType;
@@ -33,17 +33,17 @@ export const useServiceManagement = () => {
       .length;
     const instanceNumber = existingInstances + 1;
     const instanceId = `${templateType}-${instanceNumber}`;
-    
+
     // For general service, don't set an initial display name
-    const displayName = templateType === 'general' 
-      ? '' 
-      : `${templateName}${instanceNumber > 1 ? ` ${instanceNumber}` : ''}`;
+    const displayName = templateType === "general"
+      ? ""
+      : `${templateName}${instanceNumber > 1 ? ` ${instanceNumber}` : ""}`;
 
     setPendingService({
       type: templateType,
       name: templateName,
       instanceId,
-      displayName
+      displayName,
     });
     setShowServiceConfig(true);
   }, [configurations]);
@@ -56,15 +56,15 @@ export const useServiceManagement = () => {
         url,
         apiKey,
         displayName: displayName || pendingService.displayName,
-        accessUrl
+        accessUrl,
       } as ServiceConfig);
-      
-      toast.success(`Added new service instance`);
+
+      toast.success("Added new service instance");
       setShowServiceConfig(false);
       setPendingService(null);
     } catch (err) {
-      toast.error('Failed to add service instance');
-      console.error('Error adding service:', err);
+      toast.error("Failed to add service instance");
+      console.error("Error adding service:", err);
     }
   }, [pendingService, updateConfiguration]);
 
@@ -76,10 +76,10 @@ export const useServiceManagement = () => {
   const removeServiceInstance = useCallback(async (instanceId: string) => {
     try {
       await deleteConfiguration(instanceId);
-      toast.success('Service instance removed');
+      toast.success("Service instance removed");
     } catch (err) {
-      toast.error('Failed to remove service instance');
-      console.error('Error removing service:', err);
+      toast.error("Failed to remove service instance");
+      console.error("Error removing service:", err);
     }
   }, [deleteConfiguration]);
 
@@ -89,6 +89,6 @@ export const useServiceManagement = () => {
     showServiceConfig,
     pendingService,
     confirmServiceAddition,
-    cancelServiceAddition
+    cancelServiceAddition,
   };
 };

--- a/web/src/types/auth.ts
+++ b/web/src/types/auth.ts
@@ -16,7 +16,7 @@ export interface User {
   preferred_username?: string;
   email_verified?: boolean;
   username?: string;
-  auth_type?: 'oidc' | 'builtin';
+  auth_type?: "oidc" | "builtin";
 }
 
 export interface LoginCredentials {

--- a/web/src/types/service.ts
+++ b/web/src/types/service.ts
@@ -3,28 +3,28 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-export type ServiceStatus = 'online' | 'offline' | 'warning' | 'error' | 'loading' | 'pending' | 'unknown';
+export type ServiceStatus = "online" | "offline" | "warning" | "error" | "loading" | "pending" | "unknown";
 
 export type ServiceType =
-  | 'autobrr'
-  | 'radarr'
-  | 'sonarr'
-  | 'lidarr'
-  | 'readarr'
-  | 'bazarr'
-  | 'sabnzbd'
-  | 'nzbget'
-  | 'prowlarr'
-  | 'traefik'
-  | 'overseerr'
-  | 'plex'
-  | 'jellyfin'
-  | 'uptimekuma'
-  | 'tailscale'
-  | 'maintainerr'
-  | 'qui'
-  | 'general'
-  | 'other';
+  | "autobrr"
+  | "radarr"
+  | "sonarr"
+  | "lidarr"
+  | "readarr"
+  | "bazarr"
+  | "sabnzbd"
+  | "nzbget"
+  | "prowlarr"
+  | "traefik"
+  | "overseerr"
+  | "plex"
+  | "jellyfin"
+  | "uptimekuma"
+  | "tailscale"
+  | "maintainerr"
+  | "qui"
+  | "general"
+  | "other";
 
 export interface ServiceHealth {
   status: ServiceStatus;
@@ -244,8 +244,8 @@ export interface PlexTranscodeSession {
   progress: number;
   speed: number;
   size: number;
-  videoDecision: 'transcode' | 'copy' | 'direct play';
-  audioDecision: 'transcode' | 'copy' | 'direct play';
+  videoDecision: "transcode" | "copy" | "direct play";
+  audioDecision: "transcode" | "copy" | "direct play";
   protocol: string;
   container: string;
   videoCodec: string;

--- a/web/src/utils/api.ts
+++ b/web/src/utils/api.ts
@@ -16,7 +16,7 @@ const createRequest = (method: string, data?: unknown): RequestInit => {
   const options: RequestInit = {
     method,
     headers: getDefaultHeaders(),
-    credentials: 'include',
+    credentials: "include",
   };
 
   if (data) {
@@ -36,7 +36,7 @@ const getTimeoutForPath = (path: string): number => {
 
 // Utility to unregister service worker
 const unregisterServiceWorker = async (): Promise<void> => {
-  if ('serviceWorker' in navigator) {
+  if ("serviceWorker" in navigator) {
     const registrations = await navigator.serviceWorker.getRegistrations();
     for (const registration of registrations) {
       await registration.unregister();
@@ -49,12 +49,12 @@ const isNoRedirectOn401Endpoint = (path: string): boolean => {
   // Endpoints where a 401 should be surfaced to the caller (bad creds, etc),
   // not treated as "session expired, redirect to /login".
   const paths = [
-    '/api/auth/login',
-    '/api/auth/register',
-    '/api/auth/registration-status',
-    '/api/auth/config',
-    '/api/auth/oidc/login',
-    '/api/auth/oidc/logout',
+    "/api/auth/login",
+    "/api/auth/register",
+    "/api/auth/registration-status",
+    "/api/auth/config",
+    "/api/auth/oidc/login",
+    "/api/auth/oidc/logout",
   ];
   return paths.some((p) => path.includes(p));
 };
@@ -69,9 +69,9 @@ const handleRequest = async <T>(
   customTimeout?: number
 ): Promise<T> => {
   const timeout = customTimeout ?? getTimeoutForPath(path);
-  
+
   try {
-    const apiPath = path.startsWith('/api') ? path : `/api${path}`;
+    const apiPath = path.startsWith("/api") ? path : `/api${path}`;
     const url = apiPath;
 
     const controller = new AbortController();
@@ -92,7 +92,7 @@ const handleRequest = async <T>(
     if (response.status === 401) {
       // Prevent multiple auth handlers from running simultaneously
       if (isHandlingAuth) {
-        throw new Error('Authentication in progress');
+        throw new Error("Authentication in progress");
       }
 
       if (isNoRedirectOn401Endpoint(apiPath)) {
@@ -100,20 +100,20 @@ const handleRequest = async <T>(
       }
 
       isHandlingAuth = true;
-      localStorage.removeItem('auth_type');
+      localStorage.removeItem("auth_type");
 
       // Dev-only: stale Workbox caches can cause "unstyled Tailwind" reload loops.
       if (import.meta.env.DEV) {
         await unregisterServiceWorker();
       }
 
-      window.location.href = '/login';
-      throw new Error('Authentication required');
+      window.location.href = "/login";
+      throw new Error("Authentication required");
     }
 
     if (!response.ok) {
       if (response.status === 429 && retryCount < 3) {
-        const retryAfter = parseInt(response.headers.get('Retry-After') || '0');
+        const retryAfter = parseInt(response.headers.get("Retry-After") || "0");
         const waitTime = retryAfter ? retryAfter * 1000 : Math.min(1000 * Math.pow(2, retryCount), 30000);
         await new Promise(resolve => setTimeout(resolve, waitTime));
         return handleRequest<T>(path, options, retryCount + 1, customTimeout);
@@ -128,8 +128,8 @@ const handleRequest = async <T>(
       return {} as T;
     }
 
-    const contentType = response.headers.get('content-type') || '';
-    if (contentType.includes('application/json')) {
+    const contentType = response.headers.get("content-type") || "";
+    if (contentType.includes("application/json")) {
       return (await response.json()) as T;
     }
 
@@ -138,7 +138,7 @@ const handleRequest = async <T>(
     return text as unknown as T;
   } catch (error) {
     if (error instanceof Error) {
-      if (error.name === 'AbortError') {
+      if (error.name === "AbortError") {
         throw new Error(`Request timed out after ${timeout}ms`, { cause: error });
       }
       throw error;
@@ -149,18 +149,18 @@ const handleRequest = async <T>(
 
 export const api = {
   get: async <T>(path: string, timeout?: number): Promise<T> => {
-    return handleRequest<T>(path, createRequest('GET'), 0, timeout);
+    return handleRequest<T>(path, createRequest("GET"), 0, timeout);
   },
 
   post: async <T>(path: string, data?: unknown, timeout?: number): Promise<T> => {
-    return handleRequest<T>(path, createRequest('POST', data), 0, timeout);
+    return handleRequest<T>(path, createRequest("POST", data), 0, timeout);
   },
 
   put: async <T>(path: string, data: unknown, timeout?: number): Promise<T> => {
-    return handleRequest<T>(path, createRequest('PUT', data), 0, timeout);
+    return handleRequest<T>(path, createRequest("PUT", data), 0, timeout);
   },
 
   delete: async <T>(path: string, timeout?: number): Promise<T> => {
-    return handleRequest<T>(path, createRequest('DELETE'), 0, timeout);
+    return handleRequest<T>(path, createRequest("DELETE"), 0, timeout);
   },
 };

--- a/web/src/utils/index.ts
+++ b/web/src/utils/index.ts
@@ -4,5 +4,5 @@
  */
 
 export function classNames(...classes: (string | boolean | undefined | null)[]): string {
-  return classes.filter(Boolean).join(' ');
+  return classes.filter(Boolean).join(" ");
 }

--- a/web/src/utils/mediaTypes.ts
+++ b/web/src/utils/mediaTypes.ts
@@ -10,57 +10,57 @@ import {
   SparklesIcon
 } from "@heroicons/react/24/outline";
 
-export type MediaType = 'Movie' | 'Show' | 'Anime' | 'Game' | 'Book' | 'Audio' | 'Application' | 'Adult' | 'Other';
+export type MediaType = "Movie" | "Show" | "Anime" | "Game" | "Book" | "Audio" | "Application" | "Adult" | "Other";
 
 export function getMediaType(category: string): MediaType {
   const lowercase = category.toLowerCase();
-  
+
   // Anime specific detection
-  if (lowercase.includes('anime') || lowercase.includes('ona') || lowercase.includes('ova')) {
-    return 'Anime';
+  if (lowercase.includes("anime") || lowercase.includes("ona") || lowercase.includes("ova")) {
+    return "Anime";
   }
-  
+
   // Movies
-  if (lowercase.includes('movie') || lowercase.includes('3d') || lowercase.includes('bluray')) {
-    return 'Movie';
+  if (lowercase.includes("movie") || lowercase.includes("3d") || lowercase.includes("bluray")) {
+    return "Movie";
   }
-  
+
   // TV Shows
-  if (lowercase.includes('tv') || lowercase.includes('show') || 
-      lowercase.includes('episode') || lowercase.includes('season')) {
-    return 'Show';
+  if (lowercase.includes("tv") || lowercase.includes("show") ||
+      lowercase.includes("episode") || lowercase.includes("season")) {
+    return "Show";
   }
-  
+
   // Games
-  if (lowercase.includes('game') || lowercase.includes('nintendo') || 
-      lowercase.includes('playstation') || lowercase.includes('visual novel')) {
-    return 'Game';
+  if (lowercase.includes("game") || lowercase.includes("nintendo") ||
+      lowercase.includes("playstation") || lowercase.includes("visual novel")) {
+    return "Game";
   }
-  
+
   // Books and Reading Material
-  if (lowercase.includes('book') || lowercase.includes('manga') || 
-      lowercase.includes('comic') || lowercase.includes('magazine') ||
-      lowercase.includes('novel')) {
-    return 'Book';
+  if (lowercase.includes("book") || lowercase.includes("manga") ||
+      lowercase.includes("comic") || lowercase.includes("magazine") ||
+      lowercase.includes("novel")) {
+    return "Book";
   }
-  
+
   // Audio content
-  if (lowercase.includes('audio') || lowercase.includes('music') || 
-      lowercase.includes('flac')) {
-    return 'Audio';
+  if (lowercase.includes("audio") || lowercase.includes("music") ||
+      lowercase.includes("flac")) {
+    return "Audio";
   }
-  
+
   // Applications and Software
-  if (lowercase.includes('app') || lowercase.includes('software')) {
-    return 'Application';
+  if (lowercase.includes("app") || lowercase.includes("software")) {
+    return "Application";
   }
-  
+
   // Adult content
-  if (lowercase.includes('xxx') || lowercase.includes('adult')) {
-    return 'Adult';
+  if (lowercase.includes("xxx") || lowercase.includes("adult")) {
+    return "Adult";
   }
-  
-  return 'Other';
+
+  return "Other";
 }
 
 export const mediaTypeIcons = {

--- a/web/tests/browser/service-layout.spec.ts
+++ b/web/tests/browser/service-layout.spec.ts
@@ -37,8 +37,8 @@ test("compact card density stays tighter than regular", async ({ page }) => {
 test("collapse shell removes idle header gap until expanded", async ({ page }) => {
   await mountHarness(page);
 
-  const shellHeader = page.locator('[data-testid="shell-card"] > div > div').first();
-  const shellContent = page.locator('[data-testid="shell-card"] > div > div').nth(1);
+  const shellHeader = page.locator("[data-testid=\"shell-card\"] > div > div").first();
+  const shellContent = page.locator("[data-testid=\"shell-card\"] > div > div").nth(1);
 
   await expect(shellHeader).toHaveClass(/mb-0/);
   await expect(shellContent).toHaveClass(/max-h-0/);
@@ -52,10 +52,10 @@ test("collapse shell removes idle header gap until expanded", async ({ page }) =
 test("section collapse preference persists and stays key-isolated", async ({ page }) => {
   await mountHarness(page);
 
-  const quiHeader = page.locator('[data-testid="prefs-qui"] > div > div').first();
-  const quiContent = page.locator('[data-testid="prefs-qui"] > div > div').nth(1);
+  const quiHeader = page.locator("[data-testid=\"prefs-qui\"] > div > div").first();
+  const quiContent = page.locator("[data-testid=\"prefs-qui\"] > div > div").nth(1);
   const radarrContent = page
-    .locator('[data-testid="prefs-radarr"] > div > div')
+    .locator("[data-testid=\"prefs-radarr\"] > div > div")
     .nth(1);
 
   await expect(quiContent).toHaveClass(/max-h-\[1000px\]/);

--- a/web/tests/overseerr.status.test.ts
+++ b/web/tests/overseerr.status.test.ts
@@ -5,7 +5,7 @@ import {
   getRequestStatus,
   OVERSEERR_MEDIA_STATUS,
   OVERSEERR_REQUEST_STATUS,
-  resolveRequestStatus,
+  resolveRequestStatus
 } from "../src/components/services/overseerr/status.ts";
 import type { OverseerrMediaRequest } from "../src/types/service.ts";
 

--- a/web/tests/serviceCardContent.test.ts
+++ b/web/tests/serviceCardContent.test.ts
@@ -4,7 +4,7 @@ import test from "node:test";
 import {
   getServiceCardLayoutClasses,
   SERVICE_CARD_LAYOUT,
-  hasMeaningfulServiceContent,
+  hasMeaningfulServiceContent
 } from "../src/utils/serviceCardContent.ts";
 import type { Service } from "../src/types/service.ts";
 

--- a/web/tests/serviceData.merge.test.ts
+++ b/web/tests/serviceData.merge.test.ts
@@ -4,7 +4,7 @@ import {
   deriveHealthUpdate,
   hydrateServicesFromConfigurations,
   mergeServicePatchSnapshot,
-  type ServicePatchSnapshot,
+  type ServicePatchSnapshot
 } from "../src/hooks/serviceData/merge.ts";
 import type { Service } from "../src/types/service.ts";
 


### PR DESCRIPTION
Ports qui's eslint rule set into dashbrr now that both repos are on the same stack (vite 8, eslint 10, typescript-eslint 8, TS 6). Adds `@stylistic` with qui's formatting rules, explicit react-hooks rules, `no-explicit-any` as an error, and `reactRefresh.configs.vite`. The 310 changed lines are all `eslint --fix` output — formatting only, no behaviour change.

Two deliberate divergences from qui, both because dashbrr differs from it: the `scripts/**/*.js` block stays (qui has no equivalent script, and the shared config matches `.ts/.tsx` only, so dropping it would silently stop linting `generate-pwa-icons.js`), and `@stylistic/multiline-ternary` is omitted (dashbrr uses nested multiline ternaries for JSX className logic — collapsing them produced 300+ char lines with mangled `cond? a: b` spacing, as no companion spacing rule is enabled). Also drops `parserOptions.project`, which no type-aware rule was reading since the config uses `recommended` rather than `recommendedTypeChecked`.

Based on the dependabot branch since it needs eslint 10 — retarget to develop once #120 merges. Verified: typecheck, lint, build, and 22/22 tests all pass.