### PR TITLE
feat(general): display API response fields on the service card

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Dashbrr provides real-time monitoring, service health checks, and unified manage
 
 - **Uptime Kuma**: Monitor status summary via metrics
 - **Traefik**: Router/service/middleware overview and issue routers
-- **General Service**: Generic health endpoint checks
+- **General Service**: Generic health endpoint checks; displays top-level fields of a JSON response (e.g. tracker stats) as a key/value table
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Dashbrr provides real-time monitoring, service health checks, and unified manage
 
 - **Uptime Kuma**: Monitor status summary via metrics
 - **Traefik**: Router/service/middleware overview and issue routers
-- **General Service**: Generic health endpoint checks; displays top-level fields of a JSON response (e.g. tracker stats) as a key/value table
+- **General Service**: Generic health endpoint checks. Shows the top-level fields of a JSON response (for example, tracker stats) as a key/value table
 
 ## Installation
 

--- a/docs/services_matrix.md
+++ b/docs/services_matrix.md
@@ -12,7 +12,7 @@ Notes:
 | --- | --- | --- | --- | --- | --- | --- |
 | Autobrr | `autobrr` | `autobrr` | API key | Yes | `/api/autobrr/stats`, `/api/autobrr/irc`, `/api/autobrr/releases` | 120s |
 | Bazarr | `bazarr` | `bazarr` | API key | Yes | `/api/bazarr/summary` | 90s |
-| General | `generic` | `general` | API key/token | Optional | none (health only) | n/a |
+| General | `generic` | `general` | API key/token | Optional | none (health poll also surfaces top-level JSON fields on the card) | n/a |
 | Jellyfin | `jellyfin` | `jellyfin` | API key | Yes | `/api/jellyfin/summary` | 10s |
 | Lidarr | `lidarr` | `lidarr` | API key | Yes | `/api/lidarr/queue` | 60s |
 | Maintainerr | `maintainerr` | `maintainerr` | API key | Yes | `/api/maintainerr/collections` | 10m |

--- a/docs/services_matrix.md
+++ b/docs/services_matrix.md
@@ -1,18 +1,18 @@
 # Supported Services Matrix
 
-This matrix tracks current service support across CLI/discovery/auth and poller detail jobs.
+This matrix shows the support for each service: CLI commands, discovery, credentials, and poller detail jobs.
 
 Notes:
 
 - All configured services also receive baseline health polling.
-- Poll intervals below are for service-specific detail jobs in `internal/api/handlers/poller.go`.
-- CLI command group for the generic service is `generic`; discovery key is `general`.
+- The poll intervals in the table apply to the service-specific detail jobs in `internal/api/handlers/poller.go`.
+- The CLI command group for the generic service is `generic`. The discovery key is `general`.
 
 | Service | CLI Group | Discovery Key | Credential | Required | Detail Endpoint(s) | Poll Interval |
 | --- | --- | --- | --- | --- | --- | --- |
 | Autobrr | `autobrr` | `autobrr` | API key | Yes | `/api/autobrr/stats`, `/api/autobrr/irc`, `/api/autobrr/releases` | 120s |
 | Bazarr | `bazarr` | `bazarr` | API key | Yes | `/api/bazarr/summary` | 90s |
-| General | `generic` | `general` | API key/token | Optional | none (health poll also surfaces top-level JSON fields on the card) | n/a |
+| General | `generic` | `general` | API key/token | Optional | none (the health poll also shows top-level JSON fields on the card) | n/a |
 | Jellyfin | `jellyfin` | `jellyfin` | API key | Yes | `/api/jellyfin/summary` | 10s |
 | Lidarr | `lidarr` | `lidarr` | API key | Yes | `/api/lidarr/queue` | 60s |
 | Maintainerr | `maintainerr` | `maintainerr` | API key | Yes | `/api/maintainerr/collections` | 10m |

--- a/internal/services/general/general.go
+++ b/internal/services/general/general.go
@@ -91,6 +91,23 @@ func (s *GeneralService) CheckHealth(ctx context.Context, url, apiKey string) (m
 			"responseTime": responseTime,
 		}
 
+		// Expose top-level scalar fields so the UI can display arbitrary API
+		// payloads (e.g. tracker stats) as a key/value table (#87). Nested
+		// values are skipped, and status/message are already consumed above.
+		fields := make(map[string]any)
+		for key, value := range jsonResponse {
+			if key == "status" || key == "message" {
+				continue
+			}
+			switch value.(type) {
+			case string, float64, bool:
+				fields[key] = value
+			}
+		}
+		if len(fields) > 0 {
+			extras["details"] = map[string]any{"general": fields}
+		}
+
 		return s.CreateHealthResponse(startTime, status, message, extras), resp.StatusCode
 	}
 

--- a/internal/services/general/general_test.go
+++ b/internal/services/general/general_test.go
@@ -16,7 +16,7 @@ import (
 func TestCheckHealth_ExposesScalarFields(t *testing.T) {
 	t.Parallel()
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{
 			"username": "soup",

--- a/internal/services/general/general_test.go
+++ b/internal/services/general/general_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package general
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Top-level scalar fields from arbitrary JSON payloads are exposed via
+// details.general for display (#87); nested values and the health-check
+// status/message keys are not.
+func TestCheckHealth_ExposesScalarFields(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"username": "soup",
+			"ratio": "2.34",
+			"seeding": 120,
+			"can_download": true,
+			"status": "ok",
+			"message": "hello",
+			"nested": {"skip": "me"},
+			"list": [1, 2]
+		}`))
+	}))
+	defer server.Close()
+
+	service := NewGeneralService().(*GeneralService)
+	health, code := service.CheckHealth(context.Background(), server.URL, "")
+
+	if code != http.StatusOK {
+		t.Fatalf("code = %d, want %d", code, http.StatusOK)
+	}
+	if health.Status != "online" {
+		t.Fatalf("Status = %q, want %q", health.Status, "online")
+	}
+
+	fields, ok := health.Details["general"].(map[string]any)
+	if !ok {
+		t.Fatalf("Details[\"general\"] missing, Details = %#v", health.Details)
+	}
+	for _, key := range []string{"username", "ratio", "seeding", "can_download"} {
+		if _, ok := fields[key]; !ok {
+			t.Errorf("fields[%q] missing", key)
+		}
+	}
+	for _, key := range []string{"status", "message", "nested", "list"} {
+		if _, ok := fields[key]; ok {
+			t.Errorf("fields[%q] should be excluded", key)
+		}
+	}
+}

--- a/web/src/components/services/general/GeneralStats.tsx
+++ b/web/src/components/services/general/GeneralStats.tsx
@@ -12,6 +12,14 @@ interface GeneralStatsProps {
   instanceId: string;
 }
 
+const MAX_FIELDS = 12;
+
+const prettifyKey = (key: string): string =>
+  key
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+
 export const GeneralStats: React.FC<GeneralStatsProps> = ({ instanceId }) => {
   const { getService } = useServiceData();
   const service = getService(instanceId);
@@ -28,10 +36,24 @@ export const GeneralStats: React.FC<GeneralStatsProps> = ({ instanceId }) => {
   // Only show message component if there's a message or status isn't online
   const showMessage = service.message || service.status !== "online";
 
+  const fields = Object.entries(service.details?.general ?? {})
+    .sort(([a], [b]) => a.localeCompare(b))
+    .slice(0, MAX_FIELDS);
+
   return (
     <div className="space-y-4">
       {showMessage && (
         <ArrMessage status={service.status} message={service.message} />
+      )}
+      {fields.length > 0 && (
+        <div className="text-xs rounded-md bg-gray-850/95 p-3.5">
+          {fields.map(([key, value]) => (
+            <div key={key} className="flex justify-between gap-4 py-0.5">
+              <span className="text-gray-600 dark:text-gray-400">{prettifyKey(key)}</span>
+              <span className="text-gray-700 dark:text-gray-200 truncate">{String(value)}</span>
+            </div>
+          ))}
+        </div>
       )}
     </div>
   );

--- a/web/src/types/service.ts
+++ b/web/src/types/service.ts
@@ -928,6 +928,7 @@ export interface ServiceStats {
 
 // Service Details Union Type
 export interface ServiceDetails {
+  general?: Record<string, string | number | boolean>;
   autobrr?: {
     irc: AutobrrIRC[];
     base_url: string;


### PR DESCRIPTION
Extends the General service to display the JSON its URL returns: top-level scalar fields (strings, numbers, bools) are passed through the existing `details` channel on the health response and rendered as a key/value table on the card, capped at 12 rows with prettified keys and verbatim values. Nested values are skipped, `status`/`message` stay reserved for the health check, and non-JSON responses behave exactly as before.

No new service type, endpoints, or auth options — data refreshes on the normal health-check cycle, and query-param tokens (e.g. Unit3D's `?api_token=`) already work by putting them in the URL. Closes #87.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Health checks now display additional top-level service details, including text, numeric, and Boolean values.
  - General service details appear in a dedicated, readable panel with consistent formatting and alphabetical ordering.
  - The display is limited to 12 details for a concise overview.
  - Nested objects and arrays are excluded to keep health information clear and easy to scan.
  - Documentation now explains how general service details appear in service cards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->