### PR TITLE
feat(logger): add DASHBRR__LOG_LEVEL and [log] config

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ listen_addr = ":8080"
 [database]
 type = "sqlite"
 path = "./data/dashbrr.db"
+
+[log]
+# trace, debug, info, warn, error, fatal, panic
+level = "info"
 ```
 
 By default, the database file will be created in the same directory as your configuration file. For example:
@@ -181,6 +185,7 @@ Key configuration options include:
 - Server settings (listen address, ports)
 - Database settings (SQLite/PostgreSQL)
 - Authentication (Built-in/OIDC)
+- Log level (`DASHBRR__LOG_LEVEL`)
 
 ### Service Discovery
 

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - DASHBRR__DB_PASSWORD=dashbrr
       - DASHBRR__DB_NAME=dashbrr
       - DASHBRR__LISTEN_ADDR=0.0.0.0:8080
+      #- DASHBRR__LOG_LEVEL=info
 
       #- OIDC_ISSUER=optional
       #- OIDC_CLIENT_ID=optional

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -33,6 +33,14 @@ Only needed if you serve the web UI from a different origin than the API (differ
   - Purpose: Preflight cache max-age, in hours
   - Default: `12`
 
+## Logging
+
+- `DASHBRR__LOG_LEVEL`
+  - Purpose: Lowest log level that dashbrr writes
+  - Values: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic`
+  - Default: `info`
+  - Note: You can also set this level in `config.toml`, as `level` under `[log]`. The environment variable has priority.
+
 ## Configuration Path
 
 - `DASHBRR__CONFIG_PATH`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/pelletier/go-toml/v2"
 	"github.com/rs/zerolog/log"
+
+	"github.com/autobrr/dashbrr/internal/logger"
 )
 
 const (
@@ -23,6 +25,12 @@ type Config struct {
 	Server   ServerConfig   `toml:"server"`
 	Database DatabaseConfig `toml:"database"`
 	Auth     AuthConfig     `toml:"auth"`
+	Log      LogConfig      `toml:"log"`
+}
+
+// LogConfig holds logging-related configuration
+type LogConfig struct {
+	Level string `toml:"level" env:"DASHBRR__LOG_LEVEL"`
 }
 
 // ServerConfig holds server-related configuration
@@ -74,6 +82,7 @@ func DefaultConfig() *Config {
 			Type: "sqlite",
 			Path: "./data/dashbrr.db",
 		},
+		Log: LogConfig{Level: "info"},
 	}
 }
 
@@ -263,6 +272,11 @@ func LoadEnvOverrides(config *Config) error {
 		config.Database.Name = env
 	}
 
+	// Log
+	if env := os.Getenv("DASHBRR__LOG_LEVEL"); env != "" {
+		config.Log.Level = env
+	}
+
 	// Auth OIDC
 	if env := os.Getenv("OIDC_ISSUER"); env != "" {
 		config.Auth.OIDC.Issuer = env
@@ -276,6 +290,9 @@ func LoadEnvOverrides(config *Config) error {
 	if env := os.Getenv("OIDC_REDIRECT_URL"); env != "" {
 		config.Auth.OIDC.RedirectURL = env
 	}
+
+	// Every config path goes through this function, so it is the one place that applies the level.
+	logger.SetLevel(config.Log.Level)
 
 	return nil
 }

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -39,4 +39,20 @@ func Init() {
 		},
 	}
 	log.Logger = zerolog.New(output).With().Timestamp().Logger()
+
+	// Set the level from the environment first, so that early logs use it.
+	// LoadEnvOverrides calls SetLevel again with the value from the config file.
+	SetLevel(os.Getenv("DASHBRR__LOG_LEVEL"))
+}
+
+// SetLevel sets the global log level. If the value is empty or unknown, SetLevel uses info.
+func SetLevel(level string) {
+	parsed, err := zerolog.ParseLevel(strings.ToLower(strings.TrimSpace(level)))
+	if err != nil || parsed == zerolog.NoLevel {
+		if level != "" {
+			log.Warn().Str("level", level).Msg("Unknown log level, dashbrr uses info instead")
+		}
+		parsed = zerolog.InfoLevel
+	}
+	zerolog.SetGlobalLevel(parsed)
 }

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2024, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package logger
+
+import (
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func TestSetLevel(t *testing.T) {
+	tests := []struct {
+		input string
+		want  zerolog.Level
+	}{
+		{"debug", zerolog.DebugLevel},
+		{"WARN", zerolog.WarnLevel},
+		{" error ", zerolog.ErrorLevel},
+		{"", zerolog.InfoLevel},
+		{"nonsense", zerolog.InfoLevel},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			SetLevel(tt.input)
+			if got := zerolog.GlobalLevel(); got != tt.want {
+				t.Errorf("SetLevel(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Dashbrr never set a zerolog level, so it wrote every trace and debug line with no way to turn them off. The level now comes from `DASHBRR__LOG_LEVEL` or from `level` under `[log]` in config.toml. The environment variable has priority. The default is `info`. An empty or unknown value also gives `info`, with a warning.

`LoadEnvOverrides` applies the level, so every config path reaches it: the config file, environment-only setups, and the CLI subcommands.

Closes #79