### PR TITLE
feat(oidc)!: prefix env vars with DASHBRR__ and read them from config.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,13 @@ path = "./data/dashbrr.db"
 [log]
 # trace, debug, info, warn, error, fatal, panic
 level = "info"
+
+# Optional: OpenID Connect. You can also set these with DASHBRR__OIDC_* variables.
+# [auth.oidc]
+# issuer = "https://your-provider.com"
+# client_id = "your-client-id"
+# client_secret = "your-client-secret"
+# redirect_url = "http://localhost:3000/api/auth/oidc/callback"
 ```
 
 By default, the database file will be created in the same directory as your configuration file. For example:

--- a/README.md
+++ b/README.md
@@ -236,10 +236,10 @@ Enterprise-grade authentication with support for providers like Auth0.
 Required OIDC environment variables:
 
 ```bash
-OIDC_ISSUER=https://your-provider.com
-OIDC_CLIENT_ID=your-client-id
-OIDC_CLIENT_SECRET=your-client-secret
-OIDC_REDIRECT_URL=http://localhost:3000/api/auth/oidc/callback
+DASHBRR__OIDC_ISSUER=https://your-provider.com
+DASHBRR__OIDC_CLIENT_ID=your-client-id
+DASHBRR__OIDC_CLIENT_SECRET=your-client-secret
+DASHBRR__OIDC_REDIRECT_URL=http://localhost:3000/api/auth/oidc/callback
 ```
 
 ## Tech Stack

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -19,10 +19,10 @@ services:
       - DASHBRR__LISTEN_ADDR=0.0.0.0:8080
       #- DASHBRR__LOG_LEVEL=info
 
-      #- OIDC_ISSUER=optional
-      #- OIDC_CLIENT_ID=optional
-      #- OIDC_CLIENT_SECRET=optional
-      #- OIDC_REDIRECT_URL=optional
+      #- DASHBRR__OIDC_ISSUER=optional
+      #- DASHBRR__OIDC_CLIENT_ID=optional
+      #- DASHBRR__OIDC_CLIENT_SECRET=optional
+      #- DASHBRR__OIDC_REDIRECT_URL=optional
     volumes:
       - ./data:/data
     depends_on:

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -96,22 +96,24 @@ Only needed if you serve the web UI from a different origin than the API (differ
 
 (Optional OpenID Connect configuration)
 
-- `OIDC_ISSUER`
+CAUTION: These four variables had no prefix before. If you use `OIDC_ISSUER`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, or `OIDC_REDIRECT_URL`, add the `DASHBRR__` prefix. Dashbrr ignores the old names and writes a warning at startup.
+
+- `DASHBRR__OIDC_ISSUER`
 
   - Purpose: Your OIDC provider's issuer URL
   - Required if using OIDC
 
-- `OIDC_CLIENT_ID`
+- `DASHBRR__OIDC_CLIENT_ID`
 
   - Purpose: Client ID from your OIDC provider
   - Required if using OIDC
 
-- `OIDC_CLIENT_SECRET`
+- `DASHBRR__OIDC_CLIENT_SECRET`
 
   - Purpose: Client secret from your OIDC provider
   - Required if using OIDC
 
-- `OIDC_REDIRECT_URL`
+- `DASHBRR__OIDC_REDIRECT_URL`
   - Purpose: Callback URL for OIDC authentication
   - Example: `http://localhost:3000/api/auth/oidc/callback` (legacy `/api/auth/callback` also works)
   - Required if using OIDC

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -98,6 +98,8 @@ Only needed if you serve the web UI from a different origin than the API (differ
 
 CAUTION: These four variables had no prefix before. If you use `OIDC_ISSUER`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, or `OIDC_REDIRECT_URL`, add the `DASHBRR__` prefix. Dashbrr ignores the old names and writes a warning at startup.
 
+You can also set these four values in `config.toml`, under `[auth.oidc]`, as `issuer`, `client_id`, `client_secret`, and `redirect_url`. The environment variables have priority.
+
 - `DASHBRR__OIDC_ISSUER`
 
   - Purpose: Your OIDC provider's issuer URL

--- a/internal/api/handlers/auth_config.go
+++ b/internal/api/handlers/auth_config.go
@@ -5,41 +5,38 @@ package handlers
 
 import (
 	"net/http"
-	"os"
 
 	"github.com/autobrr/dashbrr/internal/api/middleware"
 	"github.com/gin-gonic/gin"
 )
 
-// GetAuthConfig returns the available authentication methods
-func GetAuthConfig(c *gin.Context) {
-	if middleware.IsAuthBypassEnabled() {
+// AuthConfig returns a handler that reports the available authentication methods.
+func AuthConfig(hasOIDC bool) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if middleware.IsAuthBypassEnabled() {
+			c.JSON(http.StatusOK, gin.H{
+				"methods": map[string]bool{
+					"builtin": true,
+					"oidc":    false,
+				},
+				"default": "builtin",
+				"bypass":  true,
+			})
+			return
+		}
+
+		defaultMethod := "builtin"
+		if hasOIDC {
+			defaultMethod = "oidc"
+		}
+
 		c.JSON(http.StatusOK, gin.H{
 			"methods": map[string]bool{
-				"builtin": true,
-				"oidc":    false,
+				"builtin": !hasOIDC, // Built-in auth is only available when OIDC is not configured
+				"oidc":    hasOIDC,
 			},
-			"default": "builtin",
-			"bypass":  true,
+			"default": defaultMethod,
+			"bypass":  false,
 		})
-		return
 	}
-
-	hasOIDC := os.Getenv("DASHBRR__OIDC_ISSUER") != "" &&
-		os.Getenv("DASHBRR__OIDC_CLIENT_ID") != "" &&
-		os.Getenv("DASHBRR__OIDC_CLIENT_SECRET") != ""
-
-	defaultMethod := "builtin"
-	if hasOIDC {
-		defaultMethod = "oidc"
-	}
-
-	c.JSON(http.StatusOK, gin.H{
-		"methods": map[string]bool{
-			"builtin": !hasOIDC, // Built-in auth is only available when OIDC is not configured
-			"oidc":    hasOIDC,
-		},
-		"default": defaultMethod,
-		"bypass":  false,
-	})
 }

--- a/internal/api/handlers/auth_config.go
+++ b/internal/api/handlers/auth_config.go
@@ -25,9 +25,9 @@ func GetAuthConfig(c *gin.Context) {
 		return
 	}
 
-	hasOIDC := os.Getenv("OIDC_ISSUER") != "" &&
-		os.Getenv("OIDC_CLIENT_ID") != "" &&
-		os.Getenv("OIDC_CLIENT_SECRET") != ""
+	hasOIDC := os.Getenv("DASHBRR__OIDC_ISSUER") != "" &&
+		os.Getenv("DASHBRR__OIDC_CLIENT_ID") != "" &&
+		os.Getenv("DASHBRR__OIDC_CLIENT_SECRET") != ""
 
 	defaultMethod := "builtin"
 	if hasOIDC {

--- a/internal/api/handlers/auth_config_test.go
+++ b/internal/api/handlers/auth_config_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2024, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestAuthConfig(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name        string
+		hasOIDC     bool
+		wantOIDC    bool
+		wantBuiltin bool
+		wantDefault string
+	}{
+		{"oidc configured", true, true, false, "oidc"},
+		{"oidc not configured", false, false, true, "builtin"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("DASHBRR_AUTH_BYPASS", "false")
+
+			r := gin.New()
+			r.GET("/api/auth/config", AuthConfig(tt.hasOIDC))
+
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/auth/config", nil))
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+			}
+
+			var got struct {
+				Methods map[string]bool `json:"methods"`
+				Default string          `json:"default"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+				t.Fatal(err)
+			}
+
+			if got.Methods["oidc"] != tt.wantOIDC {
+				t.Errorf("methods.oidc = %v, want %v", got.Methods["oidc"], tt.wantOIDC)
+			}
+			if got.Methods["builtin"] != tt.wantBuiltin {
+				t.Errorf("methods.builtin = %v, want %v", got.Methods["builtin"], tt.wantBuiltin)
+			}
+			if got.Default != tt.wantDefault {
+				t.Errorf("default = %q, want %q", got.Default, tt.wantDefault)
+			}
+		})
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -20,6 +20,9 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// defaultOIDCCallbackURL is used when the config does not set a redirect URL.
+const defaultOIDCCallbackURL = "http://localhost:3000/api/auth/oidc/callback"
+
 type Server struct {
 	cfg        *config.Config
 	db         *database.DB
@@ -152,12 +155,17 @@ func (s *Server) Handler() http.Handler {
 	authMiddleware := middleware.NewAuthMiddleware(s.cache)
 
 	// Initialize OIDC if configuration is provided
-	if hasOIDCConfig() {
+	oidc := s.cfg.Auth.OIDC
+	if oidc.IsConfigured() {
+		redirectURL := oidc.RedirectURL
+		if redirectURL == "" {
+			redirectURL = defaultOIDCCallbackURL
+		}
 		authConfig := &types.AuthConfig{
-			Issuer:       getEnvOrDefault("DASHBRR__OIDC_ISSUER", ""),
-			ClientID:     getEnvOrDefault("DASHBRR__OIDC_CLIENT_ID", ""),
-			ClientSecret: getEnvOrDefault("DASHBRR__OIDC_CLIENT_SECRET", ""),
-			RedirectURL:  getEnvOrDefault("DASHBRR__OIDC_REDIRECT_URL", "http://localhost:3000/api/auth/oidc/callback"),
+			Issuer:       oidc.Issuer,
+			ClientID:     oidc.ClientID,
+			ClientSecret: oidc.ClientSecret,
+			RedirectURL:  redirectURL,
 		}
 		oidcAuthHandler = handlers.NewAuthHandler(authConfig, s.cache)
 	}
@@ -171,7 +179,7 @@ func (s *Server) Handler() http.Handler {
 		})
 
 		// Auth configuration endpoint
-		public.GET("/api/auth/config", handlers.GetAuthConfig)
+		public.GET("/api/auth/config", handlers.AuthConfig(oidc.IsConfigured()))
 
 		// OIDC auth endpoints (only if OIDC is configured)
 		if oidcAuthHandler != nil {
@@ -369,19 +377,4 @@ func (s *Server) Handler() http.Handler {
 	web.ServeStatic(r)
 
 	return r
-}
-
-// hasOIDCConfig checks if all required OIDC configuration is provided
-func hasOIDCConfig() bool {
-	return os.Getenv("DASHBRR__OIDC_ISSUER") != "" &&
-		os.Getenv("DASHBRR__OIDC_CLIENT_ID") != "" &&
-		os.Getenv("DASHBRR__OIDC_CLIENT_SECRET") != ""
-}
-
-// getEnvOrDefault returns the value of an environment variable or a default value if not set
-func getEnvOrDefault(key, defaultValue string) string {
-	if value, exists := os.LookupEnv(key); exists {
-		return value
-	}
-	return defaultValue
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -154,10 +154,10 @@ func (s *Server) Handler() http.Handler {
 	// Initialize OIDC if configuration is provided
 	if hasOIDCConfig() {
 		authConfig := &types.AuthConfig{
-			Issuer:       getEnvOrDefault("OIDC_ISSUER", ""),
-			ClientID:     getEnvOrDefault("OIDC_CLIENT_ID", ""),
-			ClientSecret: getEnvOrDefault("OIDC_CLIENT_SECRET", ""),
-			RedirectURL:  getEnvOrDefault("OIDC_REDIRECT_URL", "http://localhost:3000/api/auth/oidc/callback"),
+			Issuer:       getEnvOrDefault("DASHBRR__OIDC_ISSUER", ""),
+			ClientID:     getEnvOrDefault("DASHBRR__OIDC_CLIENT_ID", ""),
+			ClientSecret: getEnvOrDefault("DASHBRR__OIDC_CLIENT_SECRET", ""),
+			RedirectURL:  getEnvOrDefault("DASHBRR__OIDC_REDIRECT_URL", "http://localhost:3000/api/auth/oidc/callback"),
 		}
 		oidcAuthHandler = handlers.NewAuthHandler(authConfig, s.cache)
 	}
@@ -373,9 +373,9 @@ func (s *Server) Handler() http.Handler {
 
 // hasOIDCConfig checks if all required OIDC configuration is provided
 func hasOIDCConfig() bool {
-	return os.Getenv("OIDC_ISSUER") != "" &&
-		os.Getenv("OIDC_CLIENT_ID") != "" &&
-		os.Getenv("OIDC_CLIENT_SECRET") != ""
+	return os.Getenv("DASHBRR__OIDC_ISSUER") != "" &&
+		os.Getenv("DASHBRR__OIDC_CLIENT_ID") != "" &&
+		os.Getenv("DASHBRR__OIDC_CLIENT_SECRET") != ""
 }
 
 // getEnvOrDefault returns the value of an environment variable or a default value if not set

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,6 +67,12 @@ type OIDCConfig struct {
 	RedirectURL  string `toml:"redirect_url" env:"DASHBRR__OIDC_REDIRECT_URL"`
 }
 
+// IsConfigured reports whether OIDC has the three values that it needs. The
+// redirect URL has a default, so it is not part of this test.
+func (c OIDCConfig) IsConfigured() bool {
+	return c.Issuer != "" && c.ClientID != "" && c.ClientSecret != ""
+}
+
 // DefaultConfig returns a configuration with default values
 func DefaultConfig() *Config {
 	return &Config{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,10 +61,10 @@ type AuthConfig struct {
 
 // OIDCConfig holds OIDC-specific configuration
 type OIDCConfig struct {
-	Issuer       string `toml:"issuer" env:"OIDC_ISSUER"`
-	ClientID     string `toml:"client_id" env:"OIDC_CLIENT_ID"`
-	ClientSecret string `toml:"client_secret" env:"OIDC_CLIENT_SECRET"`
-	RedirectURL  string `toml:"redirect_url" env:"OIDC_REDIRECT_URL"`
+	Issuer       string `toml:"issuer" env:"DASHBRR__OIDC_ISSUER"`
+	ClientID     string `toml:"client_id" env:"DASHBRR__OIDC_CLIENT_ID"`
+	ClientSecret string `toml:"client_secret" env:"DASHBRR__OIDC_CLIENT_SECRET"`
+	RedirectURL  string `toml:"redirect_url" env:"DASHBRR__OIDC_REDIRECT_URL"`
 }
 
 // DefaultConfig returns a configuration with default values
@@ -278,21 +278,37 @@ func LoadEnvOverrides(config *Config) error {
 	}
 
 	// Auth OIDC
-	if env := os.Getenv("OIDC_ISSUER"); env != "" {
+	if env := os.Getenv("DASHBRR__OIDC_ISSUER"); env != "" {
 		config.Auth.OIDC.Issuer = env
 	}
-	if env := os.Getenv("OIDC_CLIENT_ID"); env != "" {
+	if env := os.Getenv("DASHBRR__OIDC_CLIENT_ID"); env != "" {
 		config.Auth.OIDC.ClientID = env
 	}
-	if env := os.Getenv("OIDC_CLIENT_SECRET"); env != "" {
+	if env := os.Getenv("DASHBRR__OIDC_CLIENT_SECRET"); env != "" {
 		config.Auth.OIDC.ClientSecret = env
 	}
-	if env := os.Getenv("OIDC_REDIRECT_URL"); env != "" {
+	if env := os.Getenv("DASHBRR__OIDC_REDIRECT_URL"); env != "" {
 		config.Auth.OIDC.RedirectURL = env
 	}
+
+	warnRenamedOIDCVars()
 
 	// Every config path goes through this function, so it is the one place that applies the level.
 	logger.SetLevel(config.Log.Level)
 
 	return nil
+}
+
+// warnRenamedOIDCVars reports OIDC variables that still use the old, unprefixed
+// name. Dashbrr ignores those names, and without this warning an upgrade
+// disables OIDC login with nothing in the log to explain it.
+func warnRenamedOIDCVars() {
+	for _, name := range []string{"OIDC_ISSUER", "OIDC_CLIENT_ID", "OIDC_CLIENT_SECRET", "OIDC_REDIRECT_URL"} {
+		if os.Getenv(name) != "" && os.Getenv("DASHBRR__"+name) == "" {
+			log.Warn().
+				Str("old", name).
+				Str("new", "DASHBRR__"+name).
+				Msg("Ignored OIDC variable with the old name, rename it")
+		}
+	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2024, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeConfig(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+const oidcTOML = `
+[auth.oidc]
+issuer = "https://toml.example.com"
+client_id = "toml-id"
+client_secret = "toml-secret"
+redirect_url = "https://toml.example.com/callback"
+`
+
+func TestOIDCFromTOML(t *testing.T) {
+	cfg, err := LoadConfig(writeConfig(t, oidcTOML))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := cfg.Auth.OIDC.Issuer; got != "https://toml.example.com" {
+		t.Errorf("issuer = %q, want the value from the config file", got)
+	}
+	if !cfg.Auth.OIDC.IsConfigured() {
+		t.Error("IsConfigured() = false, want true")
+	}
+}
+
+func TestOIDCEnvOverridesTOML(t *testing.T) {
+	t.Setenv("DASHBRR__OIDC_ISSUER", "https://env.example.com")
+
+	cfg, err := LoadConfig(writeConfig(t, oidcTOML))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := cfg.Auth.OIDC.Issuer; got != "https://env.example.com" {
+		t.Errorf("issuer = %q, want the value from the environment", got)
+	}
+	if got := cfg.Auth.OIDC.ClientID; got != "toml-id" {
+		t.Errorf("client_id = %q, want the value from the config file", got)
+	}
+}
+
+func TestOIDCIsConfigured(t *testing.T) {
+	tests := []struct {
+		name string
+		oidc OIDCConfig
+		want bool
+	}{
+		{"complete", OIDCConfig{Issuer: "i", ClientID: "c", ClientSecret: "s"}, true},
+		{"no redirect url is still complete", OIDCConfig{Issuer: "i", ClientID: "c", ClientSecret: "s"}, true},
+		{"no secret", OIDCConfig{Issuer: "i", ClientID: "c"}, false},
+		{"empty", OIDCConfig{}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.oidc.IsConfigured(); got != tt.want {
+				t.Errorf("IsConfigured() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**BREAKING CHANGE:** `OIDC_ISSUER`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET` and `OIDC_REDIRECT_URL` now need the `DASHBRR__` prefix. Every other config setting already used it, and both autobrr (`AUTOBRR__OIDC_ISSUER`) and qui (`QUI__OIDC_ISSUER`) prefix theirs. There is no fallback to the old names, but dashbrr writes a warning at startup when an old name is set and the new one is not, so an upgrade does not disable OIDC login silently.

The second commit fixes the reason the rename touched three files: `config.Auth.OIDC` was written and never read, so `[auth.oidc]` in config.toml did nothing. `server.go` and `auth_config.go` now use the loaded config, which gives OIDC the same env-plus-toml support as every other setting.