### PR TITLE
feat(uptimekuma): add interactive monitor filters

### DIFF
--- a/web/src/components/services/uptimekuma/UptimeKumaStats.tsx
+++ b/web/src/components/services/uptimekuma/UptimeKumaStats.tsx
@@ -4,19 +4,56 @@
  */
 
 import React from "react";
+import { ArrowTopRightOnSquareIcon } from "@heroicons/react/20/solid";
 
 import { useServiceData } from "../../../hooks/useServiceData";
 import { StatsSkeleton } from "../../ui/StatsSkeleton";
 import { ArrMessage } from "../common/ArrMessage";
 import { combineServiceMessage } from "../../../utils/serviceMessage";
-import { CollapsibleSection } from "../../ui/CollapsibleSection";
-import { useCollapsiblePreference } from "../../../hooks/useCollapsiblePreference";
-import { serviceSectionCollapseKey } from "../../../utils/collapsePreferences";
 import type { UptimeKumaSummary } from "../../../types/service";
+import {
+  buildUptimeKumaDashboardURL,
+  buildUptimeKumaMonitorURL,
+  getUptimeKumaMonitorView,
+  resolveUptimeKumaBaseURL,
+  type UptimeKumaFilter
+} from "./uptimeKumaView";
 
 interface UptimeKumaStatsProps {
   instanceId: string;
 }
+
+interface UptimeKumaCounts {
+  total: number;
+  up: number;
+  down: number;
+  pending: number;
+  maintenance: number;
+}
+
+interface UptimeKumaStatsViewProps {
+  baseURL: string | null;
+  counts: UptimeKumaCounts;
+  summary: UptimeKumaSummary;
+}
+
+const FILTER_TILES: Array<{
+  filter: UptimeKumaFilter;
+  label: string;
+  valueClass: string;
+  layoutClass?: string;
+}> = [
+  { filter: "total", label: "Total", valueClass: "text-zinc-100" },
+  { filter: "up", label: "Up", valueClass: "text-emerald-300" },
+  { filter: "down", label: "Down", valueClass: "text-red-300" },
+  { filter: "pending", label: "Pending", valueClass: "text-amber-300" },
+  {
+    filter: "maintenance",
+    label: "Maintenance",
+    valueClass: "text-blue-300",
+    layoutClass: "col-span-2 sm:col-span-1",
+  },
+];
 
 const EMPTY_SUMMARY: UptimeKumaSummary = {
   monitors: [],
@@ -55,16 +92,147 @@ const statusBadgeClass = (status: string): string => {
   }
 };
 
+export const UptimeKumaStatsView: React.FC<UptimeKumaStatsViewProps> = ({
+  baseURL,
+  counts,
+  summary,
+}) => {
+  const monitorViewTitleID = React.useId();
+  const [selectedFilter, setSelectedFilter] = React.useState<UptimeKumaFilter | null>(
+    null
+  );
+  const activeFilter = selectedFilter && counts[selectedFilter] > 0
+    ? selectedFilter
+    : null;
+  const monitorView = getUptimeKumaMonitorView(summary.monitors, activeFilter);
+  const dashboardURL = buildUptimeKumaDashboardURL(baseURL);
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-1.5 sm:grid-cols-5">
+        {FILTER_TILES.map(({ filter, label, valueClass, layoutClass = "" }) => {
+          const count = counts[filter];
+          const isActive = activeFilter === filter;
+
+          return (
+            <button
+              key={filter}
+              type="button"
+              disabled={count === 0}
+              aria-label={`${label} ${count}`}
+              aria-pressed={isActive}
+              onClick={() =>
+                setSelectedFilter((currentFilter) =>
+                  currentFilter === filter ? null : filter
+                )
+              }
+              className={`rounded-md bg-zinc-900/80 px-3.5 py-2 text-left text-xs outline-none transition-[background-color,box-shadow,transform] duration-150 enabled:hover:bg-zinc-900 enabled:active:translate-y-px enabled:focus-visible:ring-2 enabled:focus-visible:ring-blue-500/70 disabled:cursor-default disabled:opacity-60 ${
+                isActive ? "bg-zinc-900 ring-1 ring-inset ring-zinc-500/80" : ""
+              } ${layoutClass}`}
+            >
+              <div className="text-zinc-400">{label}</div>
+              <div className={`mt-0.5 ${valueClass}`}>{count}</div>
+            </button>
+          );
+        })}
+      </div>
+
+      {monitorView.totalCount > 0 && (
+        <section aria-labelledby={monitorViewTitleID}>
+          <div className="mb-1.5 flex items-center justify-between gap-3">
+            <h4
+              id={monitorViewTitleID}
+              className="text-xs font-semibold text-zinc-200"
+            >
+              {monitorView.title}
+            </h4>
+            <div className="flex shrink-0 items-center gap-1.5 text-[11px] text-zinc-400">
+              <span>
+                Showing {monitorView.monitors.length} of {monitorView.totalCount}
+              </span>
+              {monitorView.monitors.length < monitorView.totalCount && dashboardURL && (
+                <>
+                  <span aria-hidden="true">·</span>
+                  <a
+                    href={dashboardURL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-400 transition-colors hover:text-blue-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/70"
+                  >
+                    Open Uptime Kuma
+                  </a>
+                </>
+              )}
+            </div>
+          </div>
+          <div className="divide-y divide-zinc-700/60 border-y border-zinc-700/60">
+            {monitorView.monitors.map((monitor) => {
+              const monitorURL = buildUptimeKumaMonitorURL(baseURL, monitor.id);
+              const rowClassName =
+                "flex items-center justify-between gap-3 px-1 py-2.5 text-xs";
+              const rowContent = (
+                <>
+                  <div className="min-w-0">
+                    <div className="truncate font-medium text-zinc-200 transition-colors group-hover/monitor:text-blue-300">
+                      {monitor.name}
+                    </div>
+                    <div className="mt-0.5 flex items-center gap-2 text-zinc-400">
+                      <span className="truncate">{monitor.type || "monitor"}</span>
+                      {typeof monitor.responseTimeMs === "number" &&
+                      monitor.responseTimeMs > 0 && (
+                        <span>{monitor.responseTimeMs}ms</span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-2">
+                    <span
+                      className={`inline-flex rounded px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${statusBadgeClass(
+                        monitor.status
+                      )}`}
+                    >
+                      {humanizeStatus(monitor.status)}
+                    </span>
+                    {monitorURL && (
+                      <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5 text-zinc-600 transition-colors group-hover/monitor:text-blue-400" />
+                    )}
+                  </div>
+                </>
+              );
+
+              if (!monitorURL) {
+                return (
+                  <div key={monitor.id} className={rowClassName}>
+                    {rowContent}
+                  </div>
+                );
+              }
+
+              return (
+                <a
+                  key={monitor.id}
+                  href={monitorURL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={`Open ${monitor.name}, ${monitor.type || "monitor"}, ${humanizeStatus(
+                    monitor.status
+                  )} in Uptime Kuma`}
+                  className={`group/monitor ${rowClassName} transition-colors hover:bg-zinc-900/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/70`}
+                >
+                  {rowContent}
+                </a>
+              );
+            })}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+};
+
 export const UptimeKumaStats: React.FC<UptimeKumaStatsProps> = ({ instanceId }) => {
   const { getService } = useServiceData();
   const service = getService(instanceId);
   const summary = service?.stats?.uptimekuma?.summary ?? EMPTY_SUMMARY;
-
-  const { isExpanded: issuesExpanded, toggle: toggleIssues } =
-    useCollapsiblePreference(
-      serviceSectionCollapseKey(instanceId, "uptimekuma:issues"),
-      true
-    );
 
   const isInitialLoading =
     service?.status === "loading" && !service?.stats?.uptimekuma?.summary;
@@ -86,75 +254,16 @@ export const UptimeKumaStats: React.FC<UptimeKumaStatsProps> = ({ instanceId }) 
   const maintenance =
     service.details?.uptimekuma?.maintenance ??
     countByStatus(summary, "maintenance");
-
-  const issueMonitors = summary.monitors.filter(
-    (monitor) => monitor.status === "down" || monitor.status === "pending"
-  );
+  const baseURL = resolveUptimeKumaBaseURL(service.accessUrl, service.url);
 
   return (
     <div className="space-y-4">
       <ArrMessage status={service.status} message={message} />
-
-      <div className="grid grid-cols-2 gap-1.5 sm:grid-cols-5">
-        <div className="rounded-md bg-zinc-900/80 px-3.5 py-2 text-xs">
-          <div className="text-zinc-400">Total</div>
-          <div className="mt-0.5 text-zinc-100">{total}</div>
-        </div>
-        <div className="rounded-md bg-zinc-900/80 px-3.5 py-2 text-xs">
-          <div className="text-zinc-400">Up</div>
-          <div className="mt-0.5 text-emerald-300">{up}</div>
-        </div>
-        <div className="rounded-md bg-zinc-900/80 px-3.5 py-2 text-xs">
-          <div className="text-zinc-400">Down</div>
-          <div className="mt-0.5 text-red-300">{down}</div>
-        </div>
-        <div className="rounded-md bg-zinc-900/80 px-3.5 py-2 text-xs">
-          <div className="text-zinc-400">Pending</div>
-          <div className="mt-0.5 text-amber-300">{pending}</div>
-        </div>
-        <div className="rounded-md bg-zinc-900/80 px-3.5 py-2 text-xs col-span-2 sm:col-span-1">
-          <div className="text-zinc-400">Maintenance</div>
-          <div className="mt-0.5 text-blue-300">{maintenance}</div>
-        </div>
-      </div>
-
-      {issueMonitors.length > 0 && (
-        <CollapsibleSection
-          title="Monitors With Issues"
-          meta={`${issueMonitors.length}`}
-          isExpanded={issuesExpanded}
-          onToggle={toggleIssues}
-        >
-          <div className="space-y-1.5">
-            {issueMonitors.slice(0, 10).map((monitor) => (
-              <div
-                key={monitor.id}
-                className="rounded-md bg-zinc-900/80 px-3.5 py-2 text-xs"
-              >
-                <div className="flex items-center justify-between gap-2">
-                  <div className="truncate font-medium text-zinc-200">
-                    {monitor.name}
-                  </div>
-                  <span
-                    className={`inline-flex rounded px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${statusBadgeClass(
-                      monitor.status
-                    )}`}
-                  >
-                    {humanizeStatus(monitor.status)}
-                  </span>
-                </div>
-                <div className="mt-1 flex items-center justify-between gap-2 text-zinc-400">
-                  <span className="truncate">{monitor.type || "monitor"}</span>
-                  {typeof monitor.responseTimeMs === "number" &&
-                    monitor.responseTimeMs > 0 && (
-                    <span>{monitor.responseTimeMs}ms</span>
-                  )}
-                </div>
-              </div>
-            ))}
-          </div>
-        </CollapsibleSection>
-      )}
+      <UptimeKumaStatsView
+        baseURL={baseURL}
+        counts={{ total, up, down, pending, maintenance }}
+        summary={summary}
+      />
     </div>
   );
 };

--- a/web/src/components/services/uptimekuma/uptimeKumaView.ts
+++ b/web/src/components/services/uptimekuma/uptimeKumaView.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026, s0up and the autobrr contributors.
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+import type { UptimeKumaMonitor } from "../../../types/service";
+
+export const UPTIME_KUMA_MONITOR_ROW_LIMIT = 5;
+
+export type UptimeKumaFilter =
+  | "total"
+  | "up"
+  | "down"
+  | "pending"
+  | "maintenance";
+
+export interface UptimeKumaMonitorView {
+  title: string;
+  totalCount: number;
+  monitors: UptimeKumaMonitor[];
+}
+
+const parseUptimeKumaBaseURL = (
+  baseURL: string | null | undefined
+): URL | null => {
+  const candidate = baseURL?.trim();
+  if (!candidate) return null;
+
+  try {
+    const url = new URL(candidate);
+    return url.protocol === "http:" || url.protocol === "https:" ? url : null;
+  } catch {
+    return null;
+  }
+};
+
+const buildUptimeKumaURL = (
+  baseURL: string | null | undefined,
+  path: string
+): string | null => {
+  const url = parseUptimeKumaBaseURL(baseURL);
+  if (!url) return null;
+
+  const basePath = url.pathname.replace(/\/+$/, "");
+  url.pathname = `${basePath}${path}`;
+  url.search = "";
+  url.hash = "";
+  return url.toString();
+};
+
+export const resolveUptimeKumaBaseURL = (
+  accessURL: string | null | undefined,
+  serviceURL: string | null | undefined
+): string | null => {
+  for (const candidate of [accessURL, serviceURL]) {
+    if (parseUptimeKumaBaseURL(candidate)) return candidate?.trim() ?? null;
+  }
+
+  return null;
+};
+
+export const buildUptimeKumaDashboardURL = (
+  baseURL: string | null | undefined
+): string | null =>
+  buildUptimeKumaURL(baseURL, "/dashboard");
+
+export const buildUptimeKumaMonitorURL = (
+  baseURL: string | null | undefined,
+  monitorID: string
+): string | null =>
+  buildUptimeKumaURL(baseURL, `/dashboard/${encodeURIComponent(monitorID)}`);
+
+const issuePriority = (monitor: UptimeKumaMonitor): number =>
+  monitor.status === "down" ? 0 : 1;
+
+export const getUptimeKumaMonitorView = (
+  monitors: UptimeKumaMonitor[],
+  filter: UptimeKumaFilter | null
+): UptimeKumaMonitorView => {
+  const filteredMonitors = filter === null
+    ? monitors.filter(
+      (monitor) => monitor.status === "down" || monitor.status === "pending"
+    )
+    : filter === "total"
+      ? monitors
+      : monitors.filter((monitor) => monitor.status === filter);
+
+  const sortedMonitors = filter === null
+    ? [...filteredMonitors].sort((left, right) => {
+      const priorityDifference = issuePriority(left) - issuePriority(right);
+      if (priorityDifference !== 0) return priorityDifference;
+      return left.name.localeCompare(right.name, undefined, {
+        sensitivity: "base",
+      });
+    })
+    : filteredMonitors;
+
+  const title = filter === null
+    ? "Needs Attention"
+    : filter === "total"
+      ? "All Monitors"
+      : `${filter[0].toUpperCase()}${filter.slice(1)} Monitors`;
+
+  return {
+    title,
+    totalCount: filteredMonitors.length,
+    monitors: sortedMonitors.slice(0, UPTIME_KUMA_MONITOR_ROW_LIMIT),
+  };
+};

--- a/web/tests/browser/uptimekuma-card-harness.html
+++ b/web/tests/browser/uptimekuma-card-harness.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Uptime Kuma Card Harness</title>
+    <link rel="stylesheet" href="/src/index.css" />
+  </head>
+  <body class="bg-zinc-900 p-4 text-zinc-100">
+    <div id="app"></div>
+    <script type="module" src="/tests/browser/uptimekuma-card-harness.tsx"></script>
+  </body>
+</html>

--- a/web/tests/browser/uptimekuma-card-harness.tsx
+++ b/web/tests/browser/uptimekuma-card-harness.tsx
@@ -1,0 +1,47 @@
+import { createRoot } from "react-dom/client";
+
+import { UptimeKumaStatsView } from "../../src/components/services/uptimekuma/UptimeKumaStats";
+import type { UptimeKumaMonitor } from "../../src/types/service";
+
+const monitors: UptimeKumaMonitor[] = [
+  { id: "1", name: "API", type: "http", status: "up", responseTimeMs: 24 },
+  { id: "2", name: "Cache", type: "redis", status: "down" },
+  { id: "3", name: "Database", type: "tcp", status: "down" },
+  { id: "4", name: "Indexer", type: "http", status: "down" },
+  { id: "5", name: "Queue", type: "docker", status: "down" },
+  { id: "6", name: "Search", type: "http", status: "down" },
+  { id: "7", name: "Website", type: "http", status: "down" },
+  { id: "8", name: "Worker", type: "docker", status: "pending" },
+  { id: "9", name: "Deploy", type: "push", status: "maintenance" },
+];
+
+const app = document.getElementById("app");
+
+if (!app) {
+  throw new Error("missing app mount");
+}
+
+createRoot(app).render(
+  <main className="mx-auto max-w-3xl space-y-6">
+    <section
+      data-testid="primary-card"
+      className="rounded-lg border border-zinc-700 bg-zinc-800 p-4"
+    >
+      <UptimeKumaStatsView
+        baseURL="https://kuma.example/internal"
+        counts={{ total: 9, up: 1, down: 6, pending: 1, maintenance: 1 }}
+        summary={{ monitors }}
+      />
+    </section>
+    <section
+      data-testid="zero-count-card"
+      className="rounded-lg border border-zinc-700 bg-zinc-800 p-4"
+    >
+      <UptimeKumaStatsView
+        baseURL={null}
+        counts={{ total: 1, up: 1, down: 0, pending: 0, maintenance: 0 }}
+        summary={{ monitors: monitors.slice(0, 1) }}
+      />
+    </section>
+  </main>
+);

--- a/web/tests/browser/uptimekuma-card.spec.ts
+++ b/web/tests/browser/uptimekuma-card.spec.ts
@@ -1,0 +1,102 @@
+import { expect, test } from "@playwright/test";
+
+const HARNESS_PATH = "/tests/browser/uptimekuma-card-harness.html";
+
+test("issues auto-open with a five-row cap", async ({ page }) => {
+  await page.goto(HARNESS_PATH);
+  const card = page.getByTestId("primary-card");
+
+  await expect(card.getByRole("heading", { name: "Needs Attention" })).toBeVisible();
+  await expect(card.getByRole("link", { name: /Open .* in Uptime Kuma/ })).toHaveCount(5);
+  const cacheLink = card.getByRole("link", {
+    name: "Open Cache, redis, Down in Uptime Kuma",
+  });
+  await expect(cacheLink).toHaveAttribute(
+    "href",
+    "https://kuma.example/internal/dashboard/2"
+  );
+  await expect(cacheLink).toHaveAttribute("target", "_blank");
+  await expect(cacheLink).toHaveAttribute("rel", "noopener noreferrer");
+  await expect(card.getByText("Showing 5 of 7")).toBeVisible();
+  await expect(card.getByRole("link", { name: "Open Uptime Kuma" })).toHaveAttribute(
+    "href",
+    "https://kuma.example/internal/dashboard"
+  );
+  await expect(card.getByText("API", { exact: true })).toHaveCount(0);
+  await expect(card.getByText("Worker", { exact: true })).toHaveCount(0);
+});
+
+test("all nonzero stat tiles filter the monitor list", async ({ page }) => {
+  await page.goto(HARNESS_PATH);
+  const card = page.getByTestId("primary-card");
+
+  const cases = [
+    { tile: "Total 9", heading: "All Monitors", visibleLink: /Open API,.*Up.*in Uptime Kuma/ },
+    { tile: "Up 1", heading: "Up Monitors", visibleLink: /Open API,.*Up.*in Uptime Kuma/ },
+    { tile: "Down 6", heading: "Down Monitors", visibleLink: /Open Cache,.*Down.*in Uptime Kuma/ },
+    { tile: "Pending 1", heading: "Pending Monitors", visibleLink: /Open Worker,.*Pending.*in Uptime Kuma/ },
+    {
+      tile: "Maintenance 1",
+      heading: "Maintenance Monitors",
+      visibleLink: /Open Deploy,.*Maintenance.*in Uptime Kuma/,
+    },
+  ];
+
+  for (const { tile, heading, visibleLink } of cases) {
+    const button = card.getByRole("button", { name: tile });
+    await button.click();
+    await expect(button).toHaveAttribute("aria-pressed", "true");
+    await expect(card.getByRole("heading", { name: heading })).toBeVisible();
+    await expect(card.getByRole("link", { name: visibleLink })).toBeVisible();
+  }
+});
+
+test("clicking the active filter returns to needs attention", async ({ page }) => {
+  await page.goto(HARNESS_PATH);
+  const card = page.getByTestId("primary-card");
+  const upButton = card.getByRole("button", { name: "Up 1" });
+
+  await upButton.click();
+  await expect(card.getByRole("heading", { name: "Up Monitors" })).toBeVisible();
+
+  await upButton.click();
+  await expect(upButton).toHaveAttribute("aria-pressed", "false");
+  await expect(
+    card.getByRole("heading", { name: "Needs Attention" })
+  ).toBeVisible();
+});
+
+test("zero-count stat tiles are disabled", async ({ page }) => {
+  await page.goto(HARNESS_PATH);
+
+  const card = page.getByTestId("zero-count-card");
+  await expect(card.getByRole("button", { name: "Down 0" })).toBeDisabled();
+  await expect(card.getByRole("button", { name: "Pending 0" })).toBeDisabled();
+  await expect(card.getByRole("button", { name: "Maintenance 0" })).toBeDisabled();
+});
+
+test("monitors remain readable when no safe Uptime Kuma URL exists", async ({ page }) => {
+  await page.goto(HARNESS_PATH);
+  const card = page.getByTestId("zero-count-card");
+
+  await card.getByRole("button", { name: "Up 1" }).click();
+  await expect(card.getByText("API", { exact: true })).toBeVisible();
+  await expect(card.getByRole("link")).toHaveCount(0);
+});
+
+test("each monitor list has a unique accessible label", async ({ page }) => {
+  await page.goto(HARNESS_PATH);
+  await page
+    .getByTestId("zero-count-card")
+    .getByRole("button", { name: "Up 1" })
+    .click();
+
+  const labelledSections = await page
+    .locator("section[aria-labelledby]")
+    .evaluateAll((sections) =>
+      sections.map((section) => section.getAttribute("aria-labelledby"))
+    );
+
+  expect(labelledSections).toHaveLength(2);
+  expect(new Set(labelledSections).size).toBe(2);
+});

--- a/web/tests/uptimekuma.view.test.ts
+++ b/web/tests/uptimekuma.view.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildUptimeKumaDashboardURL,
+  buildUptimeKumaMonitorURL,
+  getUptimeKumaMonitorView,
+  resolveUptimeKumaBaseURL,
+  type UptimeKumaFilter
+} from "../src/components/services/uptimekuma/uptimeKumaView.ts";
+import type { UptimeKumaMonitor } from "../src/types/service.ts";
+
+const monitors: UptimeKumaMonitor[] = [
+  { id: "1", name: "API", type: "http", status: "up", responseTimeMs: 24 },
+  { id: "2", name: "Database", type: "tcp", status: "down" },
+  { id: "3", name: "Worker", type: "docker", status: "pending" },
+  { id: "4", name: "Website", type: "http", status: "maintenance" },
+];
+
+test("default monitor view contains only monitors needing attention", () => {
+  const view = getUptimeKumaMonitorView(monitors, null);
+
+  assert.equal(view.title, "Needs Attention");
+  assert.equal(view.totalCount, 2);
+  assert.deepEqual(
+    view.monitors.map((monitor) => monitor.id),
+    ["2", "3"]
+  );
+});
+
+test("explicit monitor filters return only their matching status", () => {
+  const cases: Array<{
+    filter: UptimeKumaFilter;
+    title: string;
+    ids: string[];
+  }> = [
+    { filter: "total", title: "All Monitors", ids: ["1", "2", "3", "4"] },
+    { filter: "up", title: "Up Monitors", ids: ["1"] },
+    { filter: "down", title: "Down Monitors", ids: ["2"] },
+    { filter: "pending", title: "Pending Monitors", ids: ["3"] },
+    { filter: "maintenance", title: "Maintenance Monitors", ids: ["4"] },
+  ];
+
+  for (const { filter, title, ids } of cases) {
+    const view = getUptimeKumaMonitorView(monitors, filter);
+    assert.equal(view.title, title);
+    assert.equal(view.totalCount, ids.length);
+    assert.deepEqual(
+      view.monitors.map((monitor) => monitor.id),
+      ids
+    );
+  }
+});
+
+test("monitor views cap rendered rows without losing the total count", () => {
+  const downMonitors: UptimeKumaMonitor[] = Array.from(
+    { length: 7 },
+    (_, index) => ({
+      id: String(index + 1),
+      name: `Monitor ${index + 1}`,
+      status: "down",
+    })
+  );
+  const view = getUptimeKumaMonitorView(downMonitors, "down");
+
+  assert.equal(view.totalCount, 7);
+  assert.deepEqual(
+    view.monitors.map((monitor) => monitor.id),
+    ["1", "2", "3", "4", "5"]
+  );
+});
+
+test("default monitor view prioritizes down before pending", () => {
+  const unordered: UptimeKumaMonitor[] = [
+    { id: "1", name: "Alpha", status: "pending" },
+    { id: "2", name: "Zulu", status: "down" },
+    { id: "3", name: "Beta", status: "down" },
+  ];
+  const view = getUptimeKumaMonitorView(unordered, null);
+
+  assert.deepEqual(
+    view.monitors.map((monitor) => monitor.id),
+    ["3", "2", "1"]
+  );
+});
+
+test("monitor links preserve the configured base path", () => {
+  assert.equal(
+    buildUptimeKumaMonitorURL(
+      "https://kuma.example/internal/status/?view=all#summary",
+      "42/a"
+    ),
+    "https://kuma.example/internal/status/dashboard/42%2Fa"
+  );
+});
+
+test("dashboard links preserve the configured base path", () => {
+  assert.equal(
+    buildUptimeKumaDashboardURL(
+      "https://kuma.example/internal/status/?view=all#summary"
+    ),
+    "https://kuma.example/internal/status/dashboard"
+  );
+});
+
+test("base URL resolution rejects unsafe URLs and falls back to the service URL", () => {
+  const serviceURL = "https://kuma.internal";
+
+  assert.equal(
+    resolveUptimeKumaBaseURL(" https://kuma.example ", serviceURL),
+    "https://kuma.example"
+  );
+  assert.equal(resolveUptimeKumaBaseURL("not a URL", serviceURL), serviceURL);
+  assert.equal(
+    resolveUptimeKumaBaseURL("javascript:alert(1)", serviceURL),
+    serviceURL
+  );
+  assert.equal(resolveUptimeKumaBaseURL("  ", serviceURL), serviceURL);
+  assert.equal(resolveUptimeKumaBaseURL("ftp://kuma.example", ""), null);
+});
+
+test("link builders return null for invalid or unsafe base URLs", () => {
+  assert.equal(buildUptimeKumaDashboardURL("not a URL"), null);
+  assert.equal(buildUptimeKumaMonitorURL("javascript:alert(1)", "42"), null);
+});


### PR DESCRIPTION
Turn the Uptime Kuma summary tiles into filters and automatically surface down or pending monitors in a capped Needs Attention list. Monitor rows now link directly to their Uptime Kuma dashboard detail page, with safe access URL fallback and accessible disabled states.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a full Uptime Kuma monitor view with status badges, response times, and monitor links.
  * Added clickable status-count filters, active-filter toggling, and dashboard access.
  * Limited monitor results to five prioritized rows for easier scanning.
  * Preserved readable monitor details when links cannot be safely generated.

* **Tests**
  * Added browser and unit coverage for filtering, ordering, links, URL handling, accessibility, and empty states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->