### PR TITLE
perf(qui): read all-time totals from transfer-info

### DIFF
--- a/internal/services/qui/qui.go
+++ b/internal/services/qui/qui.go
@@ -129,6 +129,23 @@ func (s *QuiService) GetTransferInfo(ctx context.Context, url, apiKey string, in
 	return &info, nil
 }
 
+// allTimeTotalsFromTransferInfo returns nil when qui did not report the totals,
+// sending the caller to the fallback. Both fields must be present: a half-filled
+// response would report one total as zero.
+func allTimeTotalsFromTransferInfo(info *types.QuiTransferInfo) *quiServerState {
+	if info == nil || info.AllTimeDownloaded == nil || info.AllTimeUploaded == nil {
+		return nil
+	}
+
+	return &quiServerState{
+		AllTimeDownloaded: *info.AllTimeDownloaded,
+		AllTimeUploaded:   *info.AllTimeUploaded,
+	}
+}
+
+// GetAllTimeTotals reads the all-time totals from a torrent list request. This is
+// the fallback for qui versions whose transfer-info endpoint omits them: it makes
+// qui filter and sort its whole torrent set to answer two numbers.
 func (s *QuiService) GetAllTimeTotals(ctx context.Context, url, apiKey string, instanceID int) (*quiServerState, error) {
 	var response quiTorrentsResponse
 	_, err := s.requestJSON(
@@ -240,19 +257,24 @@ func (s *QuiService) GetAggregatedTransferInfo(ctx context.Context, url, apiKey 
 		instanceID := transfers[idx].InstanceID
 		group.Go(func() error {
 			info, infoErr := s.GetTransferInfo(groupCtx, url, apiKey, instanceID)
-			allTimeTotals, allTimeErr := s.GetAllTimeTotals(groupCtx, url, apiKey, instanceID)
-
 			if infoErr != nil {
 				log.Debug().
 					Err(infoErr).
 					Str("instance", strconv.Itoa(instanceID)).
 					Msg("qui transfer-info fetch failed")
 			}
-			if allTimeErr != nil {
-				log.Debug().
-					Err(allTimeErr).
-					Str("instance", strconv.Itoa(instanceID)).
-					Msg("qui all-time totals fetch failed")
+
+			// Current qui reports the all-time totals in transfer-info itself.
+			allTimeTotals := allTimeTotalsFromTransferInfo(info)
+			if allTimeTotals == nil {
+				var allTimeErr error
+				allTimeTotals, allTimeErr = s.GetAllTimeTotals(groupCtx, url, apiKey, instanceID)
+				if allTimeErr != nil {
+					log.Debug().
+						Err(allTimeErr).
+						Str("instance", strconv.Itoa(instanceID)).
+						Msg("qui all-time totals fetch failed")
+				}
 			}
 
 			if info == nil && allTimeTotals == nil {

--- a/internal/services/qui/qui_test.go
+++ b/internal/services/qui/qui_test.go
@@ -296,3 +296,62 @@ func TestCheckHealth_SummarizesInstanceState(t *testing.T) {
 		t.Fatal("health details should not include qui.summary to avoid overwriting overview metrics")
 	}
 }
+
+// Current qui serves the all-time totals from transfer-info itself. Requesting the
+// torrent list on top of that makes qui filter and sort its whole torrent set for
+// two numbers it already sent, so the extra request must not happen at all.
+func TestGetAggregatedTransferInfo_UsesTransferInfoTotals(t *testing.T) {
+	t.Parallel()
+
+	var torrentRequests atomic.Int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-API-Key") != "test-key" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		switch r.URL.Path {
+		case "/api/instances/1/transfer-info":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{
+				"connection_status":"connected",
+				"dht_nodes":72,
+				"dl_info_data":1000,
+				"dl_info_speed":1200,
+				"dl_rate_limit":0,
+				"up_info_data":500,
+				"up_info_speed":300,
+				"up_rate_limit":0,
+				"alltime_dl":5000,
+				"alltime_ul":3000
+			}`))
+		case "/api/instances/1/torrents":
+			torrentRequests.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"serverState":{"alltime_dl":1,"alltime_ul":1}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	summary, transfers := newQuiTestService().GetAggregatedTransferInfo(
+		context.Background(),
+		server.URL,
+		"test-key",
+		[]types.QuiInstance{{ID: 1, Name: "Main", IsActive: true, Connected: true}},
+	)
+
+	if got := torrentRequests.Load(); got != 0 {
+		t.Fatalf("torrent list requests = %d, want 0", got)
+	}
+	if summary.Downloaded != 5000 || summary.Uploaded != 3000 {
+		t.Fatalf("unexpected data totals: dl=%d up=%d", summary.Downloaded, summary.Uploaded)
+	}
+	if summary.DownloadSpeed != 1200 || summary.UploadSpeed != 300 {
+		t.Fatalf("unexpected speed totals: dl=%d up=%d", summary.DownloadSpeed, summary.UploadSpeed)
+	}
+	if len(transfers) != 1 || transfers[0].Downloaded != 5000 || transfers[0].Uploaded != 3000 {
+		t.Fatalf("unexpected transfers: %#v", transfers)
+	}
+}

--- a/internal/types/qui.go
+++ b/internal/types/qui.go
@@ -27,6 +27,10 @@ type QuiTransferInfo struct {
 	Uploaded         int64  `json:"up_info_data"`
 	UploadSpeed      int64  `json:"up_info_speed"`
 	UploadRate       int64  `json:"up_rate_limit"`
+
+	// Nil against qui versions whose transfer-info endpoint omits the totals.
+	AllTimeDownloaded *int64 `json:"alltime_dl"`
+	AllTimeUploaded   *int64 `json:"alltime_ul"`
 }
 
 type QuiInstanceTransfer struct {


### PR DESCRIPTION
Reading the all-time totals meant requesting a torrent list, because older qui exposed the server state only there. qui filtered and sorted its entire torrent set to answer a request that discarded the list and kept two numbers, and dashbrr repeated it for every connected instance on every refresh. Against a 5000-torrent instance that was the heaviest call dashbrr made.

Current qui reports the totals in `transfer-info`, which dashbrr already fetches in the same pass. The torrent list request stays as the fallback for qui versions that omit them, so nothing regresses against an older server. Needs autobrr/qui#2240.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Transfer statistics now use all-time upload and download totals when available.
  * Added a fallback to retrieve totals when the primary transfer information does not provide them.
  * Transfer speeds and per-instance totals continue to be preserved.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->