### PR TITLE
fix(auth): keep sessions for 30 days

### DIFF
--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -38,6 +38,9 @@ type AuthHandler struct {
 
 const oidcSessionLookupTimeout = 5 * time.Second
 
+// Independent of the OIDC provider token, which is discarded after login.
+const sessionTTL = 30 * 24 * time.Hour
+
 func NewAuthHandler(config *types.AuthConfig, store cache.Store) *AuthHandler {
 	httpClient := &http.Client{Timeout: 1 * time.Second}
 
@@ -391,12 +394,6 @@ func (h *AuthHandler) Callback(c *gin.Context) {
 		log.Error().Msg("id_token nonce mismatch")
 		c.Redirect(http.StatusTemporaryRedirect, fmt.Sprintf("%s/login?error=invalid_nonce", frontendUrl))
 		return
-	}
-
-	sessionTTL := time.Until(token.Expiry)
-	if sessionTTL <= 0 {
-		log.Warn().Time("token_expiry", token.Expiry).Msg("OIDC token has no usable expiry, using 24h session TTL")
-		sessionTTL = 24 * time.Hour
 	}
 
 	sessionData := types.SessionData{

--- a/internal/api/handlers/builtin_auth.go
+++ b/internal/api/handlers/builtin_auth.go
@@ -202,7 +202,7 @@ func (h *BuiltinAuthHandler) Login(c *gin.Context) {
 	}
 
 	// Create session
-	expiresAt := time.Now().Add(24 * time.Hour)
+	expiresAt := time.Now().Add(sessionTTL)
 	sessionData := types.SessionData{
 		ExpiresAt: expiresAt,
 		UserID:    user.ID,
@@ -210,7 +210,7 @@ func (h *BuiltinAuthHandler) Login(c *gin.Context) {
 	}
 
 	// Store session in cache
-	if err := h.cache.Set(ctx, sessionCacheKey(sessionToken), sessionData, time.Until(expiresAt)); err != nil {
+	if err := h.cache.Set(ctx, sessionCacheKey(sessionToken), sessionData, sessionTTL); err != nil {
 		log.Error().Err(err).Msg("failed to store session in cache")
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
 		return
@@ -220,7 +220,7 @@ func (h *BuiltinAuthHandler) Login(c *gin.Context) {
 	c.SetCookie(
 		"session",
 		sessionToken,
-		int(time.Until(expiresAt).Seconds()),
+		int(sessionTTL.Seconds()),
 		"/",
 		"",
 		isSecureRequest(c), // Secure
@@ -230,7 +230,7 @@ func (h *BuiltinAuthHandler) Login(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{
 		"access_token": sessionToken,
 		"token_type":   "Bearer",
-		"expires_in":   int(time.Until(expiresAt).Seconds()),
+		"expires_in":   int(sessionTTL.Seconds()),
 		"user": gin.H{
 			"id":       user.ID,
 			"username": user.Username,


### PR DESCRIPTION
OIDC sessions used the lifetime of the provider access token, which is usually 5 minutes to 1 hour, so you had to log in again very often. The access token is discarded after login, so the session does not need it. Sessions now last 30 days, the same as autobrr and qui.

Built-in logins share the same constant, which changes them from 24 hours to 30 days.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized login session expiration to a fixed 30-day duration.
  * Ensured session cookies, cached sessions, and expiration details consistently use the same lifetime.
  * Prevented session duration from varying based on token expiry or falling back to 24 hours.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->