### PR TITLE
fix(uptimekuma): show all monitors and fix the clipped tile label

### DIFF
--- a/internal/services/uptimekuma/uptimekuma.go
+++ b/internal/services/uptimekuma/uptimekuma.go
@@ -218,33 +218,26 @@ func parseSummaryFromMetrics(metrics string) (types.UptimeKumaSummaryResponse, e
 }
 
 func parseMetricLine(line string) (string, map[string]string, float64, bool) {
-	fields := strings.Fields(line)
-	if len(fields) < 2 {
-		return "", nil, 0, false
-	}
-
-	value, err := strconv.ParseFloat(fields[1], 64)
-	if err != nil {
-		return "", nil, 0, false
-	}
-
-	metric := fields[0]
-	if !strings.Contains(metric, "{") {
-		return metric, map[string]string{}, value, true
-	}
-
-	start := strings.IndexByte(metric, '{')
-	end := strings.LastIndexByte(metric, '}')
+	// Label values may contain spaces, so read the value after the closing
+	// brace instead of splitting the line on whitespace.
+	start := strings.IndexByte(line, '{')
+	end := strings.LastIndexByte(line, '}')
 	if start <= 0 || end <= start {
 		return "", nil, 0, false
 	}
 
-	labels, err := parsePrometheusLabels(metric[start+1 : end])
+	valueStr, _, _ := strings.Cut(strings.TrimSpace(line[end+1:]), " ")
+	value, err := strconv.ParseFloat(valueStr, 64)
 	if err != nil {
 		return "", nil, 0, false
 	}
 
-	return metric[:start], labels, value, true
+	labels, err := parsePrometheusLabels(line[start+1 : end])
+	if err != nil {
+		return "", nil, 0, false
+	}
+
+	return line[:start], labels, value, true
 }
 
 func parsePrometheusLabels(raw string) (map[string]string, error) {

--- a/internal/services/uptimekuma/uptimekuma_test.go
+++ b/internal/services/uptimekuma/uptimekuma_test.go
@@ -83,6 +83,36 @@ monitor_response_time{monitor_id="2",monitor_name="DB"} -1`
 	}
 }
 
+func TestParseSummaryFromMetrics_LabelValuesWithSpaces(t *testing.T) {
+	t.Parallel()
+
+	// Uptime Kuma passes monitor names through to labels unsanitized, so a
+	// space in a name must not split the line. Label set and value formatting
+	// match uptime-kuma server/prometheus.js.
+	metrics := `monitor_status{monitor_id="1",monitor_name="My Media Server",monitor_type="http",monitor_url="https://media.example",monitor_hostname="null",monitor_port="null"} 1
+monitor_response_time{monitor_id="1",monitor_name="My Media Server",monitor_type="http",monitor_url="https://media.example",monitor_hostname="null",monitor_port="null"} 12
+monitor_status{monitor_id="2",monitor_name="Docker qbittorrent",monitor_type="docker",monitor_url="https://",monitor_hostname="null",monitor_port="null"} 0
+monitor_response_time{monitor_id="2",monitor_name="Docker qbittorrent",monitor_type="docker",monitor_url="https://",monitor_hostname="null",monitor_port="null"} -1`
+
+	summary, err := parseSummaryFromMetrics(metrics)
+	if err != nil {
+		t.Fatalf("parseSummaryFromMetrics() error = %v", err)
+	}
+
+	if len(summary.Monitors) != 2 {
+		t.Fatalf("monitor count = %d, want 2", len(summary.Monitors))
+	}
+	if summary.Monitors[0].Name != "Docker qbittorrent" || summary.Monitors[0].Status != "down" {
+		t.Fatalf("monitor[0] = %+v, want Docker qbittorrent down", summary.Monitors[0])
+	}
+	if summary.Monitors[1].Name != "My Media Server" || summary.Monitors[1].Status != "up" {
+		t.Fatalf("monitor[1] = %+v, want My Media Server up", summary.Monitors[1])
+	}
+	if summary.Monitors[1].ResponseTimeMs != 12 {
+		t.Fatalf("monitor[1].responseTimeMs = %d, want 12", summary.Monitors[1].ResponseTimeMs)
+	}
+}
+
 func TestCheckHealth_DownMonitorReturnsWarning(t *testing.T) {
 	t.Parallel()
 

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,4 @@
+
+# Playwright
+test-results/
+playwright-report/

--- a/web/src/components/services/uptimekuma/UptimeKumaStats.tsx
+++ b/web/src/components/services/uptimekuma/UptimeKumaStats.tsx
@@ -51,7 +51,7 @@ const FILTER_TILES: Array<{
     filter: "maintenance",
     label: "Maintenance",
     valueClass: "text-blue-300",
-    layoutClass: "col-span-2 sm:col-span-1",
+    layoutClass: "col-span-2 @md:col-span-1",
   },
 ];
 
@@ -109,7 +109,7 @@ export const UptimeKumaStatsView: React.FC<UptimeKumaStatsViewProps> = ({
 
   return (
     <div className="space-y-4">
-      <div className="grid grid-cols-2 gap-1.5 sm:grid-cols-5">
+      <div className="grid grid-cols-2 gap-1.5 @md:grid-cols-5">
         {FILTER_TILES.map(({ filter, label, valueClass, layoutClass = "" }) => {
           const count = counts[filter];
           const isActive = activeFilter === filter;
@@ -137,7 +137,7 @@ export const UptimeKumaStatsView: React.FC<UptimeKumaStatsViewProps> = ({
         })}
       </div>
 
-      {monitorView.totalCount > 0 && (
+      {monitorView.monitors.length > 0 && (
         <section aria-labelledby={monitorViewTitleID}>
           <div className="mb-1.5 flex items-center justify-between gap-3">
             <h4
@@ -147,10 +147,8 @@ export const UptimeKumaStatsView: React.FC<UptimeKumaStatsViewProps> = ({
               {monitorView.title}
             </h4>
             <div className="flex shrink-0 items-center gap-1.5 text-[11px] text-zinc-400">
-              <span>
-                Showing {monitorView.monitors.length} of {monitorView.totalCount}
-              </span>
-              {monitorView.monitors.length < monitorView.totalCount && dashboardURL && (
+              <span>{monitorView.monitors.length} monitors</span>
+              {dashboardURL && (
                 <>
                   <span aria-hidden="true">·</span>
                   <a
@@ -165,7 +163,7 @@ export const UptimeKumaStatsView: React.FC<UptimeKumaStatsViewProps> = ({
               )}
             </div>
           </div>
-          <div className="divide-y divide-zinc-700/60 border-y border-zinc-700/60">
+          <div className="max-h-80 overflow-y-auto scrollbar-small divide-y divide-zinc-700/60 border-y border-zinc-700/60">
             {monitorView.monitors.map((monitor) => {
               const monitorURL = buildUptimeKumaMonitorURL(baseURL, monitor.id);
               const rowClassName =

--- a/web/src/components/services/uptimekuma/uptimeKumaView.ts
+++ b/web/src/components/services/uptimekuma/uptimeKumaView.ts
@@ -5,8 +5,6 @@
 
 import type { UptimeKumaMonitor } from "../../../types/service";
 
-export const UPTIME_KUMA_MONITOR_ROW_LIMIT = 5;
-
 export type UptimeKumaFilter =
   | "total"
   | "up"
@@ -16,7 +14,6 @@ export type UptimeKumaFilter =
 
 export interface UptimeKumaMonitorView {
   title: string;
-  totalCount: number;
   monitors: UptimeKumaMonitor[];
 }
 
@@ -103,7 +100,6 @@ export const getUptimeKumaMonitorView = (
 
   return {
     title,
-    totalCount: filteredMonitors.length,
-    monitors: sortedMonitors.slice(0, UPTIME_KUMA_MONITOR_ROW_LIMIT),
+    monitors: sortedMonitors,
   };
 };

--- a/web/tests/browser/uptimekuma-card-harness.tsx
+++ b/web/tests/browser/uptimekuma-card-harness.tsx
@@ -25,7 +25,7 @@ createRoot(app).render(
   <main className="mx-auto max-w-3xl space-y-6">
     <section
       data-testid="primary-card"
-      className="rounded-lg border border-zinc-700 bg-zinc-800 p-4"
+      className="@container rounded-lg border border-zinc-700 bg-zinc-800 p-4"
     >
       <UptimeKumaStatsView
         baseURL="https://kuma.example/internal"
@@ -35,12 +35,22 @@ createRoot(app).render(
     </section>
     <section
       data-testid="zero-count-card"
-      className="rounded-lg border border-zinc-700 bg-zinc-800 p-4"
+      className="@container rounded-lg border border-zinc-700 bg-zinc-800 p-4"
     >
       <UptimeKumaStatsView
         baseURL={null}
         counts={{ total: 1, up: 1, down: 0, pending: 0, maintenance: 0 }}
         summary={{ monitors: monitors.slice(0, 1) }}
+      />
+    </section>
+    <section
+      data-testid="narrow-card"
+      className="@container w-72 rounded-lg border border-zinc-700 bg-zinc-800 p-4"
+    >
+      <UptimeKumaStatsView
+        baseURL={null}
+        counts={{ total: 9, up: 1, down: 6, pending: 1, maintenance: 1 }}
+        summary={{ monitors }}
       />
     </section>
   </main>

--- a/web/tests/browser/uptimekuma-card.spec.ts
+++ b/web/tests/browser/uptimekuma-card.spec.ts
@@ -2,12 +2,12 @@ import { expect, test } from "@playwright/test";
 
 const HARNESS_PATH = "/tests/browser/uptimekuma-card-harness.html";
 
-test("issues auto-open with a five-row cap", async ({ page }) => {
+test("issues auto-open and every row stays reachable", async ({ page }) => {
   await page.goto(HARNESS_PATH);
   const card = page.getByTestId("primary-card");
 
   await expect(card.getByRole("heading", { name: "Needs Attention" })).toBeVisible();
-  await expect(card.getByRole("link", { name: /Open .* in Uptime Kuma/ })).toHaveCount(5);
+  await expect(card.getByRole("link", { name: /Open .* in Uptime Kuma/ })).toHaveCount(7);
   const cacheLink = card.getByRole("link", {
     name: "Open Cache, redis, Down in Uptime Kuma",
   });
@@ -17,13 +17,18 @@ test("issues auto-open with a five-row cap", async ({ page }) => {
   );
   await expect(cacheLink).toHaveAttribute("target", "_blank");
   await expect(cacheLink).toHaveAttribute("rel", "noopener noreferrer");
-  await expect(card.getByText("Showing 5 of 7")).toBeVisible();
+  await expect(card.getByText("7 monitors")).toBeVisible();
   await expect(card.getByRole("link", { name: "Open Uptime Kuma" })).toHaveAttribute(
     "href",
     "https://kuma.example/internal/dashboard"
   );
   await expect(card.getByText("API", { exact: true })).toHaveCount(0);
-  await expect(card.getByText("Worker", { exact: true })).toHaveCount(0);
+
+  const worker = card.getByRole("link", {
+    name: "Open Worker, docker, Pending in Uptime Kuma",
+  });
+  await worker.scrollIntoViewIfNeeded();
+  await expect(worker).toBeVisible();
 });
 
 test("all nonzero stat tiles filter the monitor list", async ({ page }) => {
@@ -97,6 +102,23 @@ test("each monitor list has a unique accessible label", async ({ page }) => {
       sections.map((section) => section.getAttribute("aria-labelledby"))
     );
 
-  expect(labelledSections).toHaveLength(2);
-  expect(new Set(labelledSections).size).toBe(2);
+  expect(labelledSections).toHaveLength(3);
+  expect(new Set(labelledSections).size).toBe(3);
+});
+
+test("stat tile labels stay readable in a narrow card", async ({ page }) => {
+  await page.goto(HARNESS_PATH);
+
+  const label = page
+    .getByTestId("narrow-card")
+    .getByRole("button", { name: "Maintenance 1" })
+    .locator("div")
+    .first();
+
+  // The tile grid keys off the card width, not the viewport, so a narrow card
+  // drops to two columns instead of clipping the longest label.
+  const overflow = await label.evaluate(
+    (node) => node.scrollWidth - node.clientWidth
+  );
+  expect(overflow).toBe(0);
 });

--- a/web/tests/uptimekuma.view.test.ts
+++ b/web/tests/uptimekuma.view.test.ts
@@ -21,7 +21,6 @@ test("default monitor view contains only monitors needing attention", () => {
   const view = getUptimeKumaMonitorView(monitors, null);
 
   assert.equal(view.title, "Needs Attention");
-  assert.equal(view.totalCount, 2);
   assert.deepEqual(
     view.monitors.map((monitor) => monitor.id),
     ["2", "3"]
@@ -44,30 +43,11 @@ test("explicit monitor filters return only their matching status", () => {
   for (const { filter, title, ids } of cases) {
     const view = getUptimeKumaMonitorView(monitors, filter);
     assert.equal(view.title, title);
-    assert.equal(view.totalCount, ids.length);
     assert.deepEqual(
       view.monitors.map((monitor) => monitor.id),
       ids
     );
   }
-});
-
-test("monitor views cap rendered rows without losing the total count", () => {
-  const downMonitors: UptimeKumaMonitor[] = Array.from(
-    { length: 7 },
-    (_, index) => ({
-      id: String(index + 1),
-      name: `Monitor ${index + 1}`,
-      status: "down",
-    })
-  );
-  const view = getUptimeKumaMonitorView(downMonitors, "down");
-
-  assert.equal(view.totalCount, 7);
-  assert.deepEqual(
-    view.monitors.map((monitor) => monitor.id),
-    ["1", "2", "3", "4", "5"]
-  );
 });
 
 test("default monitor view prioritizes down before pending", () => {


### PR DESCRIPTION
Monitors with a space in their name never showed in the card. The metrics parser split each line on whitespace and read the value from the second field, but Uptime Kuma writes the labels before the value and does not escape spaces in them, so those lines were dropped without an error. The parser now reads the value after the closing brace. Verified against output from the same prom-client version Uptime Kuma pins: 23 monitors in, 11 out before, 23 after.

Also from the same report: the monitor list stopped at five rows with no way to the rest, so it is now a scrollable list of all monitors; and the stat tiles changed to five columns at a viewport width, which cut off the "Maintenance" label in a narrow card, so they now use the card width like the other cards do.

Note that Uptime Kuma removes paused monitors from `/metrics`, so those still do not appear. That is not something dashbrr can work around.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Correctly displays monitor names containing spaces in Uptime Kuma metrics.
  - Preserves monitor statuses, ordering, and response times when processing these metrics.

- **Improvements**
  - Displays all filtered monitors instead of limiting the list to five.
  - Adds a scrollable monitor list and improves responsive layouts for narrower screens.
  - Shows the current monitor count and keeps dashboard links visible when available.
  - Prevents stat labels from overflowing on compact cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->