### PR TITLE
feat(whisparr): Add Whisparr V2 Support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Dashbrr provides real-time monitoring, service health checks, and unified manage
 
 - **Plex**: Active streams monitoring, version check
 - **Jellyfin**: Active sessions monitoring, play/transcode state, version check
-- **Sonarr, Radarr, Lidarr, Readarr**:
+- **Sonarr, Radarr, Lidarr, Readarr, Whisparr**:
   - Queue visibility and download state
   - Version check and update notifications
 - **Bazarr**: Subtitle backlog, provider status, health issue visibility

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -125,6 +125,7 @@ Currently supported service command groups:
 - `tailscale`
 - `traefik`
 - `uptimekuma`
+- `whisparr`
 
 ### Autobrr
 
@@ -337,6 +338,20 @@ Example: dashbrr service sonarr remove http://localhost:8989
 dashbrr service sonarr list
 ```
 
+### Whisparr
+
+```bash
+# Add a Whisparr service
+dashbrr service whisparr add <url> <api-key>
+Example: dashbrr service whisparr add http://localhost:6969 your-api-key
+
+# Remove a Whisparr service
+dashbrr service whisparr remove <url>
+Example: dashbrr service whisparr remove http://localhost:6969
+
+# List Whisparr services
+dashbrr service whisparr list
+```
 ### NZBGet
 
 ```bash

--- a/docs/config_management.md
+++ b/docs/config_management.md
@@ -165,6 +165,7 @@ When using environment variables for API keys/tokens (`${SERVICE_API_KEY}`), the
 - `DASHBRR_TAILSCALE_API_KEY`
 - `DASHBRR_TRAEFIK_API_KEY` (optional)
 - `DASHBRR_UPTIMEKUMA_API_KEY`
+- `DASHBRR_WHISPARR_API_KEY`
 
 ## Supported Discovery Service Types
 
@@ -188,6 +189,7 @@ Discovery/import currently supports these service type keys:
 - `tailscale`
 - `traefik`
 - `uptimekuma`
+- `whisparr`
 
 ## Security Considerations
 

--- a/docs/services_matrix.md
+++ b/docs/services_matrix.md
@@ -28,3 +28,4 @@ Notes:
 | Tailscale | `tailscale` | `tailscale` | API token | Yes | `/api/tailscale/devices` | 60s |
 | Traefik | `traefik` | `traefik` | Auth token or `user:pass` | Optional | `/api/traefik/summary` | 30s |
 | Uptime Kuma | `uptimekuma` | `uptimekuma` | API key or `user:pass` | Yes | `/api/uptimekuma/summary` | 30s |
+| Whisparr | `whisparr` | `whisparr` | API key | Yes | `/api/whisparr/queue` | 60s |

--- a/internal/api/handlers/poller.go
+++ b/internal/api/handlers/poller.go
@@ -636,7 +636,11 @@ func summarizeWhisparrQueue(records []types.WhisparrQueueItem) (int, int, int64)
 		if record.Status == "downloading" {
 			downloading++
 		}
-		episodeCount += len(record.Episodes)
+		// Whisparr returns one episode (scene) per queue item rather than an
+		// array, so each entry with an episode contributes exactly one.
+		if record.EpisodeID != 0 {
+			episodeCount++
+		}
 	}
 
 	return downloading, episodeCount, totalSize

--- a/internal/api/handlers/poller.go
+++ b/internal/api/handlers/poller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/autobrr/dashbrr/internal/services/tailscale"
 	"github.com/autobrr/dashbrr/internal/services/traefik"
 	"github.com/autobrr/dashbrr/internal/services/uptimekuma"
+	"github.com/autobrr/dashbrr/internal/services/whisparr"
 	"github.com/autobrr/dashbrr/internal/types"
 )
 
@@ -132,6 +133,9 @@ func NewPoller(db *database.DB, bc *Broadcaster) *Poller {
 		},
 		"sonarr": {
 			{name: "sonarr_queue", interval: 60 * time.Second, timeout: pollerMediumJobTimeout, run: (*Poller).runSonarrQueue},
+		},
+		"whisparr": {
+			{name: "whisparr_queue", interval: 60 * time.Second, timeout: pollerMediumJobTimeout, run: (*Poller).runWhisparrQueue},
 		},
 		"prowlarr": {
 			{name: "prowlarr_stats", interval: 120 * time.Second, timeout: pollerMediumJobTimeout, run: (*Poller).runProwlarrStats},
@@ -622,6 +626,22 @@ func summarizeReadarrQueue(records []types.ReadarrQueueItem) (int, int64) {
 	return downloading, totalSize
 }
 
+func summarizeWhisparrQueue(records []types.WhisparrQueueItem) (int, int, int64) {
+	downloading := 0
+	episodeCount := 0
+	var totalSize int64
+
+	for _, record := range records {
+		totalSize += record.Size
+		if record.Status == "downloading" {
+			downloading++
+		}
+		episodeCount += len(record.Episodes)
+	}
+
+	return downloading, episodeCount, totalSize
+}
+
 func summarizeSonarrQueue(records []types.QueueRecord) (int, int, int64) {
 	downloading := 0
 	episodeCount := 0
@@ -780,6 +800,24 @@ func (p *Poller) runReadarrQueue(ctx context.Context, svc models.ServiceConfigur
 	return nil
 }
 
+func (p *Poller) runWhisparrQueue(ctx context.Context, svc models.ServiceConfiguration, _ string) error {
+	service := &whisparr.WhisparrService{}
+	records, err := service.GetQueueForHealth(ctx, svc.URL, svc.APIKey)
+	if err != nil {
+		return err
+	}
+	if records == nil {
+		records = []types.WhisparrQueueItem{}
+	}
+
+	resp := &types.WhisparrQueueResponse{
+		Records:      records,
+		TotalRecords: len(records),
+	}
+
+	publishInternalServiceUpdate(p.bc, buildWhisparrQueueServiceUpdate(svc.InstanceID, resp))
+	return nil
+}
 func (p *Poller) runSonarrQueue(ctx context.Context, svc models.ServiceConfiguration, _ string) error {
 	service := &sonarr.SonarrService{}
 	records, err := service.GetQueueForHealth(ctx, svc.URL, svc.APIKey)

--- a/internal/api/handlers/poller_stats_test.go
+++ b/internal/api/handlers/poller_stats_test.go
@@ -82,17 +82,17 @@ func TestSummarizeWhisparrQueue(t *testing.T) {
 	t.Parallel()
 
 	records := []types.WhisparrQueueItem{
-		{Status: "downloading", Size: 100, Episodes: []types.WhisparrEpisodeBasic{{}, {}}},
-		{Status: "queued", Size: 250, Episodes: []types.WhisparrEpisodeBasic{{}}},
-		{Status: "downloading", Size: 50, Episodes: nil},
+		{Status: "downloading", Size: 100, EpisodeID: 11, Episode: types.WhisparrEpisode{ID: 11}},
+		{Status: "queued", Size: 250, EpisodeID: 12, Episode: types.WhisparrEpisode{ID: 12}},
+		{Status: "downloading", Size: 50},
 	}
 
 	downloading, episodeCount, totalSize := summarizeWhisparrQueue(records)
 	if downloading != 2 {
 		t.Fatalf("summarizeWhisparrQueue() downloading = %d, want 2", downloading)
 	}
-	if episodeCount != 3 {
-		t.Fatalf("summarizeWhisparrQueue() episodeCount = %d, want 3", episodeCount)
+	if episodeCount != 2 {
+		t.Fatalf("summarizeWhisparrQueue() episodeCount = %d, want 2", episodeCount)
 	}
 	if totalSize != 400 {
 		t.Fatalf("summarizeWhisparrQueue() totalSize = %d, want 400", totalSize)

--- a/internal/api/handlers/poller_stats_test.go
+++ b/internal/api/handlers/poller_stats_test.go
@@ -78,6 +78,27 @@ func TestSummarizeReadarrQueue(t *testing.T) {
 	}
 }
 
+func TestSummarizeWhisparrQueue(t *testing.T) {
+	t.Parallel()
+
+	records := []types.WhisparrQueueItem{
+		{Status: "downloading", Size: 100, Episodes: []types.WhisparrEpisodeBasic{{}, {}}},
+		{Status: "queued", Size: 250, Episodes: []types.WhisparrEpisodeBasic{{}}},
+		{Status: "downloading", Size: 50, Episodes: nil},
+	}
+
+	downloading, episodeCount, totalSize := summarizeWhisparrQueue(records)
+	if downloading != 2 {
+		t.Fatalf("summarizeWhisparrQueue() downloading = %d, want 2", downloading)
+	}
+	if episodeCount != 3 {
+		t.Fatalf("summarizeWhisparrQueue() episodeCount = %d, want 3", episodeCount)
+	}
+	if totalSize != 400 {
+		t.Fatalf("summarizeWhisparrQueue() totalSize = %d, want 400", totalSize)
+	}
+}
+
 func TestSummarizeSonarrQueue(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/handlers/queue_hash.go
+++ b/internal/api/handlers/queue_hash.go
@@ -94,6 +94,22 @@ func wrapSonarrQueue(queue *types.SonarrQueueResponse) []QueueRecordWrapper {
 	})
 }
 
+// wrapWhisparrQueue converts WhisparrQueueResponse to slice of QueueRecordWrapper.
+func wrapWhisparrQueue(queue *types.WhisparrQueueResponse) []QueueRecordWrapper {
+	if queue == nil {
+		return nil
+	}
+
+	return wrapQueueRecords(queue.Records, func(record types.WhisparrQueueItem) QueueRecordWrapper {
+		return QueueRecordWrapper{
+			ID:     record.ID,
+			Title:  record.Title,
+			Status: record.Status,
+			Size:   record.Size,
+		}
+	})
+}
+
 // generateQueueHash creates a hash string from queue records
 func generateQueueHash(records []QueueRecordWrapper) string {
 	if len(records) == 0 {

--- a/internal/api/handlers/service_payload_builders.go
+++ b/internal/api/handlers/service_payload_builders.go
@@ -332,6 +332,29 @@ func buildReadarrQueueServiceUpdate(instanceID string, queueResp *types.ReadarrQ
 	}
 }
 
+func buildWhisparrQueueServiceUpdate(instanceID string, queueResp *types.WhisparrQueueResponse) models.ServiceHealth {
+	downloading, episodeCount, totalSize := summarizeWhisparrQueue(queueResp.Records)
+
+	return models.ServiceHealth{
+		ServiceID: instanceID,
+		Status:    "online",
+		Message:   "whisparr_queue",
+		Stats: map[string]any{
+			"whisparr": map[string]any{
+				"queue": queueResp,
+			},
+		},
+		Details: map[string]any{
+			"whisparr": map[string]any{
+				"queueCount":       queueResp.TotalRecords,
+				"totalRecords":     queueResp.TotalRecords,
+				"downloadingCount": downloading,
+				"episodeCount":     episodeCount,
+				"totalSize":        totalSize,
+			},
+		},
+	}
+}
 func buildSonarrQueueServiceUpdate(instanceID string, queueResp *types.SonarrQueueResponse) models.ServiceHealth {
 	downloading, episodeCount, totalSize := summarizeSonarrQueue(queueResp.Records)
 

--- a/internal/api/handlers/service_payload_contract_test.go
+++ b/internal/api/handlers/service_payload_contract_test.go
@@ -19,6 +19,7 @@ var canonicalServiceMessageKeys = []string{
 	"readarr_queue",
 	"sonarr_queue",
 	"sonarr_stats",
+	"whisparr_queue",
 	"prowlarr_stats",
 	"prowlarr_indexers",
 	"traefik_summary",

--- a/internal/api/handlers/whisparr.go
+++ b/internal/api/handlers/whisparr.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/autobrr/dashbrr/internal/api/middleware"
+	"github.com/autobrr/dashbrr/internal/database"
+	"github.com/autobrr/dashbrr/internal/services/cache"
+	"github.com/autobrr/dashbrr/internal/services/resilience"
+	"github.com/autobrr/dashbrr/internal/services/whisparr"
+	"github.com/autobrr/dashbrr/internal/types"
+)
+
+const (
+	whisparrQueuePrefix       = "whisparr:queue:"
+	whisparrStaleDataDuration = 5 * time.Minute
+)
+
+type WhisparrHandler struct {
+	db              *database.DB
+	cache           cache.Store
+	bc              *Broadcaster
+	circuitBreaker  *resilience.CircuitBreaker
+	lastQueueHash   map[string]string
+	lastQueueHashMu sync.Mutex
+}
+
+func NewWhisparrHandler(db *database.DB, cache cache.Store, bc *Broadcaster) *WhisparrHandler {
+	return &WhisparrHandler{
+		db:             db,
+		cache:          cache,
+		bc:             bc,
+		circuitBreaker: resilience.NewCircuitBreaker(5, 1*time.Minute),
+		lastQueueHash:  make(map[string]string),
+	}
+}
+
+func (h *WhisparrHandler) GetQueue(c *gin.Context) {
+	instanceID, ok := requireInstanceID(c, "whisparr", "Whisparr")
+	if !ok {
+		return
+	}
+
+	cacheKey := whisparrQueuePrefix + instanceID
+	ctx := c.Request.Context()
+
+	result, err := FetchWithSWRCache(ctx, SWRCacheOptions[types.WhisparrQueueResponse]{
+		Store:          h.cache,
+		CircuitBreaker: h.circuitBreaker,
+		Key:            cacheKey,
+		FreshTTL:       middleware.CacheDurations.WhisparrStatus,
+		StaleTTL:       whisparrStaleDataDuration,
+		Fetch: func() (types.WhisparrQueueResponse, error) {
+			return h.fetchQueue(ctx, instanceID)
+		},
+	})
+	if err != nil {
+		if handleArrFetchError(c, err, "Whisparr", instanceID, "queue") {
+			return
+		}
+		return
+	}
+
+	compareAndLogArrQueueChanges(
+		h.lastQueueHash,
+		&h.lastQueueHashMu,
+		"Whisparr",
+		instanceID,
+		result.TotalRecords,
+		wrapWhisparrQueue(&result),
+	)
+	if result.Records != nil {
+		publishInternalServiceUpdate(h.bc, buildWhisparrQueueServiceUpdate(instanceID, &result))
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+func (h *WhisparrHandler) fetchQueue(ctx context.Context, instanceID string) (types.WhisparrQueueResponse, error) {
+	whisparrConfig, err := requireServiceConfig(ctx, h.db, instanceID, "whisparr")
+	if err != nil {
+		return types.WhisparrQueueResponse{}, err
+	}
+
+	service := &whisparr.WhisparrService{}
+	records, err := service.GetQueueForHealth(ctx, whisparrConfig.URL, whisparrConfig.APIKey)
+	if err != nil {
+		return types.WhisparrQueueResponse{}, err
+	}
+
+	return types.WhisparrQueueResponse{
+		Records:      records,
+		TotalRecords: len(records),
+	}, nil
+}
+
+func (h *WhisparrHandler) DeleteQueueItem(c *gin.Context) {
+	instanceID, ok := requireInstanceID(c, "whisparr", "Whisparr")
+	if !ok {
+		return
+	}
+
+	queueID := c.Param("id")
+	if queueID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "queue item id is required"})
+		return
+	}
+
+	queryOptions := queueDeleteOptionsFromQuery(c)
+	options := types.WhisparrQueueDeleteOptions{
+		RemoveFromClient: queryOptions.RemoveFromClient,
+		Blocklist:        queryOptions.Blocklist,
+		SkipRedownload:   queryOptions.SkipRedownload,
+		ChangeCategory:   queryOptions.ChangeCategory,
+	}
+
+	ctx := c.Request.Context()
+	err := resilience.RetryWithBackoff(ctx, func() error {
+		return h.deleteQueueItem(ctx, instanceID, queueID, options)
+	})
+	if handleQueueDeleteError(c, err, "Whisparr", instanceID, queueID) {
+		return
+	}
+
+	cacheKey := whisparrQueuePrefix + instanceID
+	refreshQueueAfterDelete(
+		ctx,
+		h.cache,
+		h.circuitBreaker,
+		cacheKey,
+		middleware.CacheDurations.WhisparrStatus,
+		whisparrStaleDataDuration,
+		func() (types.WhisparrQueueResponse, error) {
+			return h.fetchQueue(ctx, instanceID)
+		},
+		func(result *types.WhisparrQueueResponse) {
+			publishInternalServiceUpdate(h.bc, buildWhisparrQueueServiceUpdate(instanceID, result))
+		},
+		"Whisparr",
+		instanceID,
+	)
+
+	c.JSON(http.StatusOK, gin.H{"message": "Queue item deleted successfully"})
+}
+
+func (h *WhisparrHandler) deleteQueueItem(
+	ctx context.Context,
+	instanceID, queueID string,
+	options types.WhisparrQueueDeleteOptions,
+) error {
+	whisparrConfig, err := requireServiceConfig(ctx, h.db, instanceID, "whisparr")
+	if err != nil {
+		return err
+	}
+
+	service := &whisparr.WhisparrService{}
+	return service.DeleteQueueItem(ctx, whisparrConfig.URL, whisparrConfig.APIKey, queueID, options)
+}

--- a/internal/api/middleware/cache.go
+++ b/internal/api/middleware/cache.go
@@ -34,6 +34,7 @@ var CacheDurations = struct {
 	AutobrrReleases   time.Duration
 	MaintainerrStatus time.Duration
 	SonarrStatus      time.Duration
+	WhisparrStatus    time.Duration
 	RadarrStatus      time.Duration
 	LidarrStatus      time.Duration
 	ReadarrStatus     time.Duration
@@ -55,6 +56,7 @@ var CacheDurations = struct {
 	AutobrrReleases:   1 * time.Minute,
 	MaintainerrStatus: 10 * time.Minute,
 	SonarrStatus:      1 * time.Minute,
+	WhisparrStatus:    1 * time.Minute,
 	RadarrStatus:      1 * time.Minute,
 	LidarrStatus:      1 * time.Minute,
 	ReadarrStatus:     1 * time.Minute,
@@ -178,6 +180,8 @@ func (m *CacheMiddleware) getTTL(path string) time.Duration {
 		return CacheDurations.AutobrrStatus
 	case strings.Contains(path, "/maintainerr"):
 		return CacheDurations.MaintainerrStatus
+	case strings.Contains(path, "/whisparr"):
+		return CacheDurations.WhisparrStatus
 	case strings.Contains(path, "/sonarr"):
 		return CacheDurations.SonarrStatus
 	case strings.Contains(path, "/radarr"):

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -142,6 +142,7 @@ func (s *Server) Handler() http.Handler {
 	radarrHandler := handlers.NewRadarrHandler(s.db, s.cache, bc)
 	lidarrHandler := handlers.NewLidarrHandler(s.db, s.cache, bc)
 	readarrHandler := handlers.NewReadarrHandler(s.db, s.cache, bc)
+	whisparrHandler := handlers.NewWhisparrHandler(s.db, s.cache, bc)
 	prowlarrHandler := handlers.NewProwlarrHandler(s.db, s.cache, bc)
 	traefikHandler := handlers.NewTraefikHandler(s.db, s.cache, bc)
 	bazarrHandler := handlers.NewBazarrHandler(s.db, s.cache, bc)
@@ -321,6 +322,12 @@ func (s *Server) Handler() http.Handler {
 					readarr.DELETE("/queue/:id", readarrHandler.DeleteQueueItem)
 				}
 
+				// Whisparr endpoints
+				whisparr := regularServices.Group("/whisparr")
+				{
+					whisparr.GET("/queue", whisparrHandler.GetQueue)
+					whisparr.DELETE("/queue/:id", whisparrHandler.DeleteQueueItem)
+				}
 				// Prowlarr endpoints
 				prowlarr := regularServices.Group("/prowlarr")
 				{

--- a/internal/commands/health.go
+++ b/internal/commands/health.go
@@ -28,6 +28,7 @@ import (
 	_ "github.com/autobrr/dashbrr/internal/services/sonarr"
 	_ "github.com/autobrr/dashbrr/internal/services/tailscale"
 	_ "github.com/autobrr/dashbrr/internal/services/uptimekuma"
+	_ "github.com/autobrr/dashbrr/internal/services/whisparr"
 
 	"github.com/spf13/cobra"
 )

--- a/internal/commands/service.go
+++ b/internal/commands/service.go
@@ -51,6 +51,7 @@ func ServiceCommand() *cobra.Command {
 	command.AddCommand(ServiceSonarrCommand())
 	command.AddCommand(ServiceTailscaleCommand())
 	command.AddCommand(ServiceTraefikCommand())
+	command.AddCommand(ServiceWhisparrCommand())
 
 	return command
 }

--- a/internal/commands/service_whisparr.go
+++ b/internal/commands/service_whisparr.go
@@ -1,0 +1,52 @@
+package commands
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/autobrr/dashbrr/internal/models"
+	"github.com/autobrr/dashbrr/internal/services/whisparr"
+)
+
+var whisparrServiceSpec = serviceSpec{
+	Use:         "whisparr",
+	Prefix:      "whisparr-",
+	DisplayName: "Whisparr",
+	Short:       "whisparr management",
+	Long:        "whisparr management",
+	Example:     "  dashbrr service whisparr\n  dashbrr service whisparr --help",
+	AddExample:  "  dashbrr service whisparr add http://localhost:6969 <API-KEY>\n  dashbrr service whisparr add --help",
+	AddArgs:     cobra.MinimumNArgs(2),
+	ParseAdd: func(args []string) (serviceURL, apiKey, displayName string, err error) {
+		return args[0], args[1], "Whisparr", nil
+	},
+	HealthCheck: func(ctx context.Context, serviceURL, apiKey string) (models.ServiceHealth, int) {
+		return whisparr.NewWhisparrService().CheckHealth(ctx, serviceURL, apiKey)
+	},
+}
+
+func ServiceWhisparrCommand() *cobra.Command {
+	command := &cobra.Command{
+		Use:          "whisparr",
+		Short:        whisparrServiceSpec.Short,
+		Long:         whisparrServiceSpec.Long,
+		Example:      whisparrServiceSpec.Example,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Usage()
+		},
+	}
+
+	command.AddCommand(ServiceWhisparrListCommand())
+	command.AddCommand(ServiceWhisparrAddCommand())
+	command.AddCommand(ServiceWhisparrRemoveCommand())
+
+	return command
+}
+
+func ServiceWhisparrListCommand() *cobra.Command { return newServiceListCommand(whisparrServiceSpec) }
+func ServiceWhisparrAddCommand() *cobra.Command  { return newServiceAddCommand(whisparrServiceSpec) }
+func ServiceWhisparrRemoveCommand() *cobra.Command {
+	return newServiceRemoveCommand(whisparrServiceSpec)
+}

--- a/internal/models/registry.go
+++ b/internal/models/registry.go
@@ -54,6 +54,10 @@ func (r *ServiceRegistry) CreateService(serviceType string) ServiceHealthChecker
 		if NewSonarrService != nil {
 			return NewSonarrService()
 		}
+	case "whisparr":
+		if NewWhisparrService != nil {
+			return NewWhisparrService()
+		}
 	case "lidarr":
 		if NewLidarrService != nil {
 			return NewLidarrService()

--- a/internal/models/service.go
+++ b/internal/models/service.go
@@ -52,6 +52,7 @@ var (
 	NewBazarrService      func() ServiceHealthChecker
 	NewRadarrService      func() ServiceHealthChecker
 	NewSonarrService      func() ServiceHealthChecker
+	NewWhisparrService    func() ServiceHealthChecker
 	NewLidarrService      func() ServiceHealthChecker
 	NewReadarrService     func() ServiceHealthChecker
 	NewSabnzbdService     func() ServiceHealthChecker

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -24,4 +24,5 @@ import (
 	_ "github.com/autobrr/dashbrr/internal/services/tailscale"
 	_ "github.com/autobrr/dashbrr/internal/services/traefik"
 	_ "github.com/autobrr/dashbrr/internal/services/uptimekuma"
+	_ "github.com/autobrr/dashbrr/internal/services/whisparr"
 )

--- a/internal/services/whisparr/whisparr.go
+++ b/internal/services/whisparr/whisparr.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package whisparr
+
+import (
+	"context"
+	"strings"
+
+	"github.com/autobrr/dashbrr/internal/models"
+	"github.com/autobrr/dashbrr/internal/services/arr"
+	"github.com/autobrr/dashbrr/internal/services/core"
+	"github.com/autobrr/dashbrr/internal/types"
+)
+
+//nolint:revive // named for consistency with every sibling *arr service (SonarrService, LidarrService, ...)
+type WhisparrService struct {
+	core.ServiceCore
+}
+
+func init() {
+	models.NewWhisparrService = NewWhisparrService
+}
+
+func NewWhisparrService() models.ServiceHealthChecker {
+	service := &WhisparrService{}
+	service.Type = "whisparr"
+	service.DisplayName = "Whisparr"
+	service.Description = "Monitor and manage your Whisparr instance"
+	service.DefaultURL = "http://localhost:6969"
+	service.HealthEndpoint = "/api/v3/health"
+	service.SetTimeout(core.DefaultTimeout)
+	return service
+}
+
+func (s *WhisparrService) GetHealthEndpoint(baseURL string) string {
+	baseURL = strings.TrimRight(baseURL, "/")
+	return baseURL + "/api/v3/health"
+}
+
+func (s *WhisparrService) DeleteQueueItem(
+	ctx context.Context,
+	baseURL, apiKey, queueID string,
+	options types.WhisparrQueueDeleteOptions,
+) error {
+	return arr.DeleteQueueItem(ctx, "whisparr", baseURL, apiKey, queueID, arr.QueueDeleteOptions{
+		RemoveFromClient: options.RemoveFromClient,
+		Blocklist:        options.Blocklist,
+		SkipRedownload:   options.SkipRedownload,
+		ChangeCategory:   options.ChangeCategory,
+	}, s.ReadBody)
+}
+
+func (s *WhisparrService) getQueueRecords(ctx context.Context, url, apiKey string) ([]types.WhisparrQueueItem, error) {
+	return arr.FetchQueueRecords[types.WhisparrQueueItem](
+		ctx,
+		"whisparr",
+		url,
+		apiKey,
+		"page=1&pageSize=10&includeUnknownSeriesItems=false&includeSeries=true&includeEpisode=true",
+		s.ReadBody,
+	)
+}
+
+func (s *WhisparrService) GetQueue(ctx context.Context, url, apiKey string) (any, error) {
+	records, err := s.getQueueRecords(ctx, url, apiKey)
+	if err != nil {
+		return nil, err
+	}
+	return records, nil
+}
+
+func (s *WhisparrService) GetQueueForHealth(ctx context.Context, url, apiKey string) ([]types.WhisparrQueueItem, error) {
+	return s.getQueueRecords(ctx, url, apiKey)
+}
+
+func (s *WhisparrService) GetSystemStatus(ctx context.Context, url, apiKey string) (string, error) {
+	return arr.GetArrSystemStatus(ctx, "whisparr", url, apiKey, s.GetVersionFromCache, s.CacheVersion)
+}
+
+func (s *WhisparrService) CheckForUpdates(ctx context.Context, url, apiKey string) (bool, error) {
+	return arr.CheckArrForUpdates(ctx, "whisparr", url, apiKey)
+}
+
+func (s *WhisparrService) CheckHealth(ctx context.Context, url, apiKey string) (models.ServiceHealth, int) {
+	return arr.ArrHealthCheck(ctx, &s.ServiceCore, url, apiKey, s)
+}

--- a/internal/services/whisparr/whisparr_test.go
+++ b/internal/services/whisparr/whisparr_test.go
@@ -1,0 +1,249 @@
+// Copyright (c) 2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package whisparr
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/autobrr/dashbrr/internal/services/arr"
+	"github.com/autobrr/dashbrr/internal/types"
+)
+
+// Whisparr V2 is a Sonarr V3 fork, so the service must speak /api/v3 and
+// authenticate with X-Api-Key. A wrong default port or an API version copied
+// from Lidarr would break these without failing to compile.
+func TestNewWhisparrServiceDefaults(t *testing.T) {
+	t.Parallel()
+
+	service, ok := NewWhisparrService().(*WhisparrService)
+	if !ok {
+		t.Fatalf("NewWhisparrService did not return *WhisparrService")
+	}
+
+	if got, want := service.Type, "whisparr"; got != want {
+		t.Errorf("Type = %q, want %q", got, want)
+	}
+	if got, want := service.DisplayName, "Whisparr"; got != want {
+		t.Errorf("DisplayName = %q, want %q", got, want)
+	}
+	if got, want := service.DefaultURL, "http://localhost:6969"; got != want {
+		t.Errorf("DefaultURL = %q, want %q", got, want)
+	}
+	if got, want := service.HealthEndpoint, "/api/v3/health"; got != want {
+		t.Errorf("HealthEndpoint = %q, want %q", got, want)
+	}
+}
+
+func TestGetHealthEndpoint(t *testing.T) {
+	t.Parallel()
+
+	service := &WhisparrService{}
+
+	tests := []struct {
+		name    string
+		baseURL string
+		want    string
+	}{
+		{"plain", "http://localhost:6969", "http://localhost:6969/api/v3/health"},
+		{"trailing slash", "http://localhost:6969/", "http://localhost:6969/api/v3/health"},
+		{"repeated trailing slashes", "http://localhost:6969///", "http://localhost:6969/api/v3/health"},
+		{"subpath", "https://example.com/whisparr", "https://example.com/whisparr/api/v3/health"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := service.GetHealthEndpoint(tt.baseURL); got != tt.want {
+				t.Errorf("GetHealthEndpoint(%q) = %q, want %q", tt.baseURL, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeleteQueueItem_ValidationErrorsAreArrErrors(t *testing.T) {
+	t.Parallel()
+
+	service := &WhisparrService{}
+
+	tests := []struct {
+		name    string
+		baseURL string
+		apiKey  string
+		wantMsg string
+	}{
+		{"missing url", "", "key", "URL is required"},
+		{"missing api key", "http://localhost:6969", "", "API key is required"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := service.DeleteQueueItem(
+				context.Background(),
+				tt.baseURL,
+				tt.apiKey,
+				"123",
+				types.WhisparrQueueDeleteOptions{},
+			)
+
+			var arrErr *arr.ErrArr
+			if !errors.As(err, &arrErr) {
+				t.Fatalf("expected *arr.ErrArr, got %T (%v)", err, err)
+			}
+			if arrErr.Service != "whisparr" || arrErr.Op != "delete_queue" {
+				t.Fatalf("unexpected arr error fields: %+v", arrErr)
+			}
+			if arrErr.Err == nil || arrErr.Err.Error() != tt.wantMsg {
+				t.Fatalf("unexpected validation message: got %v want %q", arrErr.Err, tt.wantMsg)
+			}
+		})
+	}
+}
+
+func TestGetQueueForHealth_RequestShapeAndParsing(t *testing.T) {
+	t.Parallel()
+
+	var gotPath, gotAPIKey, gotQuery, gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotAPIKey = r.URL.Path, r.Header.Get("X-Api-Key")
+		gotQuery, gotMethod = r.URL.RawQuery, r.Method
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"page":1,"totalRecords":2,"records":[
+			{"id":11,"title":"Scene A","status":"downloading","size":1024,"sizeleft":512,
+			 "protocol":"torrent","indexer":"idx","downloadClient":"qbit",
+			 "trackedDownloadState":"importBlocked","customFormatScore":7},
+			{"id":12,"title":"Scene B","status":"completed","size":2048}]}`))
+	}))
+	defer srv.Close()
+
+	records, err := (&WhisparrService{}).GetQueueForHealth(context.Background(), srv.URL, "secret-key")
+	if err != nil {
+		t.Fatalf("GetQueueForHealth returned error: %v", err)
+	}
+
+	if gotMethod != http.MethodGet {
+		t.Errorf("method = %q, want GET", gotMethod)
+	}
+	if gotPath != "/api/v3/queue" {
+		t.Errorf("path = %q, want /api/v3/queue", gotPath)
+	}
+	if gotAPIKey != "secret-key" {
+		t.Errorf("X-Api-Key = %q, want secret-key", gotAPIKey)
+	}
+	// Sonarr-fork queue params: series/episode, not movie or artist.
+	for _, want := range []string{
+		"includeUnknownSeriesItems=false",
+		"includeSeries=true",
+		"includeEpisode=true",
+	} {
+		if !strings.Contains(gotQuery, want) {
+			t.Errorf("query %q missing %q", gotQuery, want)
+		}
+	}
+
+	if len(records) != 2 {
+		t.Fatalf("got %d records, want 2", len(records))
+	}
+	first := records[0]
+	if first.ID != 11 || first.Title != "Scene A" || first.Status != "downloading" {
+		t.Errorf("unexpected first record: %+v", first)
+	}
+	if first.Size != 1024 || first.SizeLeft != 512 {
+		t.Errorf("size fields not parsed: size=%d sizeleft=%d", first.Size, first.SizeLeft)
+	}
+	if first.TrackedDownloadState != "importBlocked" {
+		t.Errorf("trackedDownloadState = %q, want importBlocked", first.TrackedDownloadState)
+	}
+	if first.CustomFormatScore != 7 {
+		t.Errorf("customFormatScore = %d, want 7", first.CustomFormatScore)
+	}
+}
+
+func TestGetQueueForHealth_EmptyRecordsIsNotNil(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"page":1,"totalRecords":0,"records":[]}`))
+	}))
+	defer srv.Close()
+
+	records, err := (&WhisparrService{}).GetQueueForHealth(context.Background(), srv.URL, "key")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if records == nil {
+		t.Fatal("records is nil; handler and poller rely on a non-nil empty slice")
+	}
+	if len(records) != 0 {
+		t.Fatalf("got %d records, want 0", len(records))
+	}
+}
+
+// A rejected API key is the most common misconfiguration; it must surface as an
+// *arr.ErrArr carrying the HTTP status rather than as a parse failure.
+func TestGetQueueForHealth_UnauthorizedSurfacesStatus(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	_, err := (&WhisparrService{}).GetQueueForHealth(context.Background(), srv.URL, "wrong-key")
+
+	var arrErr *arr.ErrArr
+	if !errors.As(err, &arrErr) {
+		t.Fatalf("expected *arr.ErrArr, got %T (%v)", err, err)
+	}
+	if arrErr.Service != "whisparr" || arrErr.Op != "get_queue" {
+		t.Fatalf("unexpected arr error fields: %+v", arrErr)
+	}
+	if arrErr.HttpCode != http.StatusUnauthorized {
+		t.Fatalf("HttpCode = %d, want %d", arrErr.HttpCode, http.StatusUnauthorized)
+	}
+}
+
+func TestDeleteQueueItem_SendsV3DeleteWithOptions(t *testing.T) {
+	t.Parallel()
+
+	var gotMethod, gotPath string
+	var gotQuery url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath, gotQuery = r.Method, r.URL.Path, r.URL.Query()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	err := (&WhisparrService{}).DeleteQueueItem(
+		context.Background(), srv.URL, "key", "42",
+		types.WhisparrQueueDeleteOptions{RemoveFromClient: true, Blocklist: true, ChangeCategory: true},
+	)
+	if err != nil {
+		t.Fatalf("DeleteQueueItem returned error: %v", err)
+	}
+
+	if gotMethod != http.MethodDelete {
+		t.Errorf("method = %q, want DELETE", gotMethod)
+	}
+	if gotPath != "/api/v3/queue/42" {
+		t.Errorf("path = %q, want /api/v3/queue/42", gotPath)
+	}
+	for key, want := range map[string]string{
+		"removeFromClient": "true",
+		"blocklist":        "true",
+		"skipRedownload":   "false",
+		"changeCategory":   "true",
+	} {
+		if got := gotQuery.Get(key); got != want {
+			t.Errorf("query %s = %q, want %q", key, got, want)
+		}
+	}
+}

--- a/internal/services/whisparr/whisparr_test.go
+++ b/internal/services/whisparr/whisparr_test.go
@@ -116,10 +116,16 @@ func TestGetQueueForHealth_RequestShapeAndParsing(t *testing.T) {
 		gotPath, gotAPIKey = r.URL.Path, r.Header.Get("X-Api-Key")
 		gotQuery, gotMethod = r.URL.RawQuery, r.Method
 		w.Header().Set("Content-Type", "application/json")
+		// Mirrors a real Whisparr V2 QueueResource: a singular "episode" object
+		// (not an "episodes" array), with no episodeNumber -- scenes carry a
+		// releaseDate and use seasonNumber as the release year.
 		_, _ = w.Write([]byte(`{"page":1,"totalRecords":2,"records":[
 			{"id":11,"title":"Scene A","status":"downloading","size":1024,"sizeleft":512,
 			 "protocol":"torrent","indexer":"idx","downloadClient":"qbit",
-			 "trackedDownloadState":"importBlocked","customFormatScore":7},
+			 "trackedDownloadState":"importBlocked","customFormatScore":7,
+			 "episodeId":802746,"seasonNumber":2024,
+			 "episode":{"id":802746,"seriesId":1007,"tvdbId":439,"title":"Scene A Full Title",
+			  "seasonNumber":2024,"releaseDate":"2024-11-22","runtime":120,"hasFile":false}},
 			{"id":12,"title":"Scene B","status":"completed","size":2048}]}`))
 	}))
 	defer srv.Close()
@@ -164,6 +170,29 @@ func TestGetQueueForHealth_RequestShapeAndParsing(t *testing.T) {
 	}
 	if first.CustomFormatScore != 7 {
 		t.Errorf("customFormatScore = %d, want 7", first.CustomFormatScore)
+	}
+
+	// The queue payload carries a singular episode object. Decoding it as an
+	// array silently yields zero episodes, which makes episodeCount always 0.
+	if first.EpisodeID != 802746 {
+		t.Errorf("episodeId = %d, want 802746", first.EpisodeID)
+	}
+	if first.Episode.ID != 802746 {
+		t.Errorf("episode.id = %d, want 802746", first.Episode.ID)
+	}
+	if first.Episode.Title != "Scene A Full Title" {
+		t.Errorf("episode.title = %q, want %q", first.Episode.Title, "Scene A Full Title")
+	}
+	if first.Episode.SeasonNumber != 2024 {
+		t.Errorf("episode.seasonNumber = %d, want 2024", first.Episode.SeasonNumber)
+	}
+	if first.Episode.ReleaseDate != "2024-11-22" {
+		t.Errorf("episode.releaseDate = %q, want 2024-11-22", first.Episode.ReleaseDate)
+	}
+
+	// A record without an episode must stay zero-valued rather than erroring.
+	if second := records[1]; second.EpisodeID != 0 || second.Episode.ID != 0 {
+		t.Errorf("record without episode should be zero-valued, got %+v", second.Episode)
 	}
 }
 

--- a/internal/types/whisparr.go
+++ b/internal/types/whisparr.go
@@ -37,7 +37,8 @@ type WhisparrQueueItem struct {
 	StatusMessages          []WhisparrStatusMessage `json:"statusMessages"`
 	ErrorMessage            string                  `json:"errorMessage"`
 	CustomFormatScore       int                     `json:"customFormatScore"`
-	Episodes                []WhisparrEpisodeBasic  `json:"episodes"`
+	EpisodeID               int                     `json:"episodeId"`
+	Episode                 WhisparrEpisode         `json:"episode"`
 }
 
 // WhisparrStatusMessage represents detailed status information for a queue record.
@@ -46,12 +47,22 @@ type WhisparrStatusMessage struct {
 	Messages []string `json:"messages"`
 }
 
-// WhisparrEpisodeBasic represents the minimal episode structure carried on a
-// queue item; Whisparr models these as scenes.
-type WhisparrEpisodeBasic struct {
-	ID            int `json:"id"`
-	EpisodeNumber int `json:"episodeNumber"`
-	SeasonNumber  int `json:"seasonNumber"`
+// WhisparrEpisode represents the episode carried on a queue item. Whisparr
+// models these as scenes, so there is no episode number: releases are
+// identified by release date, and seasonNumber carries the release year.
+// The API returns a single episode object per queue item, not an array.
+type WhisparrEpisode struct {
+	ID            int    `json:"id"`
+	SeriesID      int    `json:"seriesId"`
+	TvdbID        int    `json:"tvdbId"`
+	Title         string `json:"title"`
+	SeasonNumber  int    `json:"seasonNumber"`
+	ReleaseDate   string `json:"releaseDate"`
+	Runtime       int    `json:"runtime"`
+	Overview      string `json:"overview"`
+	HasFile       bool   `json:"hasFile"`
+	EpisodeFileID int    `json:"episodeFileId"`
+	Monitored     bool   `json:"monitored"`
 }
 
 // WhisparrQueueDeleteOptions represents options for deleting a queue item.

--- a/internal/types/whisparr.go
+++ b/internal/types/whisparr.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2026, s0up and the autobrr contributors.
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+package types //nolint:revive // pre-existing shared package name
+
+// Whisparr V2 is a Sonarr V3 fork, so its queue payload currently matches the
+// Sonarr shape. These types are deliberately kept separate from the Sonarr ones
+// so that Sonarr-driven changes cannot silently alter Whisparr behaviour.
+
+// WhisparrQueueResponse represents the queue response from the Whisparr API.
+type WhisparrQueueResponse struct {
+	Page          int                 `json:"page"`
+	PageSize      int                 `json:"pageSize"`
+	SortKey       string              `json:"sortKey"`
+	SortDirection string              `json:"sortDirection"`
+	TotalRecords  int                 `json:"totalRecords"`
+	Records       []WhisparrQueueItem `json:"records"`
+}
+
+// WhisparrQueueItem represents a record in the Whisparr queue.
+type WhisparrQueueItem struct {
+	ID                      int                     `json:"id"`
+	Title                   string                  `json:"title"`
+	Status                  string                  `json:"status"`
+	Size                    int64                   `json:"size"`
+	SizeLeft                int64                   `json:"sizeleft"`
+	TimeLeft                string                  `json:"timeleft,omitempty"`
+	EstimatedCompletionTime string                  `json:"estimatedCompletionTime"`
+	Added                   string                  `json:"added"`
+	DownloadClient          string                  `json:"downloadClient"`
+	DownloadID              string                  `json:"downloadId"`
+	Protocol                string                  `json:"protocol"`
+	Indexer                 string                  `json:"indexer"`
+	OutputPath              string                  `json:"outputPath"`
+	TrackedDownloadStatus   string                  `json:"trackedDownloadStatus"`
+	TrackedDownloadState    string                  `json:"trackedDownloadState"`
+	StatusMessages          []WhisparrStatusMessage `json:"statusMessages"`
+	ErrorMessage            string                  `json:"errorMessage"`
+	CustomFormatScore       int                     `json:"customFormatScore"`
+	Episodes                []WhisparrEpisodeBasic  `json:"episodes"`
+}
+
+// WhisparrStatusMessage represents detailed status information for a queue record.
+type WhisparrStatusMessage struct {
+	Title    string   `json:"title"`
+	Messages []string `json:"messages"`
+}
+
+// WhisparrEpisodeBasic represents the minimal episode structure carried on a
+// queue item; Whisparr models these as scenes.
+type WhisparrEpisodeBasic struct {
+	ID            int `json:"id"`
+	EpisodeNumber int `json:"episodeNumber"`
+	SeasonNumber  int `json:"seasonNumber"`
+}
+
+// WhisparrQueueDeleteOptions represents options for deleting a queue item.
+type WhisparrQueueDeleteOptions struct {
+	RemoveFromClient bool `json:"removeFromClient"`
+	Blocklist        bool `json:"blocklist"`
+	SkipRedownload   bool `json:"skipRedownload"`
+	ChangeCategory   bool `json:"changeCategory"`
+}

--- a/web/src/components/AddServicesMenu.tsx
+++ b/web/src/components/AddServicesMenu.tsx
@@ -52,6 +52,7 @@ const SERVICE_CATEGORY_MAP: Record<ServiceType, ServiceCategoryKey> = {
   autobrr: "AUTOMATION",
   radarr: "MEDIA_MANAGEMENT",
   sonarr: "MEDIA_MANAGEMENT",
+  whisparr: "MEDIA_MANAGEMENT",
   lidarr: "MEDIA_MANAGEMENT",
   readarr: "MEDIA_MANAGEMENT",
   bazarr: "MEDIA_MANAGEMENT",
@@ -98,6 +99,7 @@ const URL_PLACEHOLDERS: Partial<Record<ServiceType, string>> = {
   qui: "http://localhost:7476",
   traefik: "http://localhost:8080",
   bazarr: "http://localhost:6767",
+  whisparr: "http://localhost:6969",
   sabnzbd: "http://localhost:8080",
   nzbget: "http://localhost:6789",
   general: "Enter full URL including health endpoint",
@@ -113,6 +115,11 @@ const API_KEY_HELP_BY_SERVICE: Partial<
     link: getSettingsUrl("/settings/api"),
   }),
   radarr: ({ getSettingsUrl }) => ({
+    prefix: "Found in ",
+    text: "Settings > General",
+    link: getSettingsUrl("/settings/general"),
+  }),
+  whisparr: ({ getSettingsUrl }) => ({
     prefix: "Found in ",
     text: "Settings > General",
     link: getSettingsUrl("/settings/general"),

--- a/web/src/components/configuration/ConfigurationForm.tsx
+++ b/web/src/components/configuration/ConfigurationForm.tsx
@@ -118,6 +118,7 @@ export const ConfigurationForm = ({
         return "X-Plex-Token";
       case "radarr":
       case "sonarr":
+      case "whisparr":
       case "lidarr":
       case "readarr":
       case "bazarr":
@@ -160,6 +161,7 @@ export const ConfigurationForm = ({
         };
       case "radarr":
       case "sonarr":
+      case "whisparr":
       case "lidarr":
       case "readarr":
       case "bazarr":

--- a/web/src/components/configuration/ConfigurationForm.tsx
+++ b/web/src/components/configuration/ConfigurationForm.tsx
@@ -234,6 +234,8 @@ export const ConfigurationForm = ({
         return "http://localhost:3001";
       case "bazarr":
         return "http://localhost:6767";
+      case "whisparr":
+        return "http://localhost:6969";
       case "traefik":
         return "http://localhost:8080";
       case "sabnzbd":

--- a/web/src/components/services/ServiceCard.tsx
+++ b/web/src/components/services/ServiceCard.tsx
@@ -83,6 +83,9 @@ const SERVICE_STATS_RENDERERS: Partial<
         <MaintainerrService instanceId={instanceId} />
       </div>
     ) : null,
+  whisparr: (instanceId) => (
+    <ArrQueueStats instanceId={instanceId} serviceType="whisparr" />
+  ),
   sonarr: (instanceId) => (
     <ArrQueueStats instanceId={instanceId} serviceType="sonarr" />
   ),

--- a/web/src/components/services/common/ArrQueueStats.tsx
+++ b/web/src/components/services/common/ArrQueueStats.tsx
@@ -9,7 +9,12 @@ import { ServiceStats } from "../../../types/service";
 import { ArrMessage } from "./ArrMessage";
 import { ArrQueueRecord, ArrQueueStatsBase } from "./ArrQueueStatsBase";
 
-type ArrQueueServiceType = "sonarr" | "radarr" | "lidarr" | "readarr";
+type ArrQueueServiceType =
+  | "sonarr"
+  | "whisparr"
+  | "radarr"
+  | "lidarr"
+  | "readarr";
 
 interface ArrQueueStatsProps {
   instanceId: string;
@@ -17,9 +22,10 @@ interface ArrQueueStatsProps {
 }
 
 type ArrQueueStatsConfig = {
-  serviceName: "Sonarr" | "Radarr" | "Lidarr" | "Readarr";
+  serviceName: "Sonarr" | "Whisparr" | "Radarr" | "Lidarr" | "Readarr";
   queuePath:
     | "/api/sonarr/queue"
+    | "/api/whisparr/queue"
     | "/api/radarr/queue"
     | "/api/lidarr/queue"
     | "/api/readarr/queue";
@@ -39,6 +45,14 @@ const ARR_QUEUE_STATS_CONFIG: Record<ArrQueueServiceType, ArrQueueStatsConfig> =
     serviceName: "Sonarr",
     queuePath: "/api/sonarr/queue",
     getQueue: (stats) => stats.sonarr?.queue,
+    canManageRecord: (record) => record.trackedDownloadState === "importBlocked",
+    getManageDisabledReason: () =>
+      "Can only remove items that are import blocked",
+  },
+  whisparr: {
+    serviceName: "Whisparr",
+    queuePath: "/api/whisparr/queue",
+    getQueue: (stats) => stats.whisparr?.queue,
     canManageRecord: (record) => record.trackedDownloadState === "importBlocked",
     getManageDisabledReason: () =>
       "Can only remove items that are import blocked",

--- a/web/src/components/services/common/ArrQueueStatsBase.tsx
+++ b/web/src/components/services/common/ArrQueueStatsBase.tsx
@@ -110,9 +110,10 @@ const QueueOptionSelect = <T extends string>({
 type Props = {
   instanceId: string;
   // stable labels for copy/links/api
-  serviceName: "Sonarr" | "Radarr" | "Lidarr" | "Readarr";
+  serviceName: "Sonarr" | "Whisparr" | "Radarr" | "Lidarr" | "Readarr";
   queuePath:
     | "/api/sonarr/queue"
+    | "/api/whisparr/queue"
     | "/api/radarr/queue"
     | "/api/lidarr/queue"
     | "/api/readarr/queue";

--- a/web/src/config/repoUrls.ts
+++ b/web/src/config/repoUrls.ts
@@ -16,6 +16,7 @@ export const repoUrls: RepoUrls = {
   "traefik": "https://github.com/traefik/traefik/releases",
   "qui": "https://github.com/autobrr/qui/releases/",
   "sonarr": "https://github.com/Sonarr/Sonarr/releases",
+  "whisparr": "https://github.com/Whisparr/Whisparr/releases",
   "radarr": "https://github.com/Radarr/Radarr/releases",
   "lidarr": "https://github.com/Lidarr/Lidarr/releases",
   "readarr": "https://github.com/Readarr/Readarr/releases",

--- a/web/src/config/serviceTemplates.ts
+++ b/web/src/config/serviceTemplates.ts
@@ -34,6 +34,15 @@ export const serviceTemplates: Omit<Service, "id" | "instanceId">[] = [
     healthEndpoint: "/api/health/sonarr",
   },
   {
+    name: "Whisparr",
+    displayName: "",
+    type: "whisparr",
+    status: "offline",
+    url: "",
+    accessUrl: "",
+    healthEndpoint: "/api/health/whisparr",
+  },
+  {
     name: "Lidarr",
     displayName: "",
     type: "lidarr",

--- a/web/src/types/service.ts
+++ b/web/src/types/service.ts
@@ -498,6 +498,18 @@ export interface WhisparrStatusMessage {
   messages: string[];
 }
 
+// Whisparr models releases as scenes: no episodeNumber, and seasonNumber
+// carries the release year. The API returns one episode object per queue
+// item, not an array.
+export interface WhisparrEpisode {
+  id: number;
+  seriesId?: number;
+  title?: string;
+  seasonNumber?: number;
+  releaseDate?: string;
+  hasFile?: boolean;
+}
+
 export interface WhisparrQueueItem {
   id: number;
   title: string;
@@ -512,7 +524,8 @@ export interface WhisparrQueueItem {
   errorMessage?: string;
   statusMessages?: WhisparrStatusMessage[];
   size: number;
-  episodes: { id: number; episodeNumber: number; seasonNumber: number }[];
+  episodeId?: number;
+  episode?: WhisparrEpisode;
 }
 
 export interface WhisparrQueue {

--- a/web/src/types/service.ts
+++ b/web/src/types/service.ts
@@ -9,6 +9,7 @@ export type ServiceType =
   | "autobrr"
   | "radarr"
   | "sonarr"
+  | "whisparr"
   | "lidarr"
   | "readarr"
   | "bazarr"
@@ -491,6 +492,33 @@ export interface RadarrQueue {
   records: RadarrQueueItem[];
 }
 
+// Whisparr Types (V2 is a Sonarr fork, so records share the Sonarr shape)
+export interface WhisparrStatusMessage {
+  title: string;
+  messages: string[];
+}
+
+export interface WhisparrQueueItem {
+  id: number;
+  title: string;
+  status: string;
+  protocol: string; // "usenet" or "torrent"
+  indexer?: string;
+  customFormatScore: number;
+  downloadClient: string;
+  timeLeft?: string;
+  trackedDownloadState?: string;
+  trackedDownloadStatus?: string;
+  errorMessage?: string;
+  statusMessages?: WhisparrStatusMessage[];
+  size: number;
+  episodes: { id: number; episodeNumber: number; seasonNumber: number }[];
+}
+
+export interface WhisparrQueue {
+  totalRecords: number;
+  records: WhisparrQueueItem[];
+}
 // Lidarr Types
 export interface LidarrStatusMessage {
   title: string;
@@ -880,6 +908,9 @@ export interface ServiceStats {
   radarr?: {
     queue: RadarrQueue;
   };
+  whisparr?: {
+    queue: WhisparrQueue;
+  };
   lidarr?: {
     queue: LidarrQueue;
   };
@@ -963,6 +994,13 @@ export interface ServiceDetails {
     queueCount: number;
     totalRecords?: number;
     downloadingCount?: number;
+    totalSize?: number;
+  };
+  whisparr?: {
+    queueCount: number;
+    totalRecords?: number;
+    downloadingCount?: number;
+    episodeCount?: number;
     totalSize?: number;
   };
   lidarr?: {

--- a/web/src/utils/serviceCardContent.ts
+++ b/web/src/utils/serviceCardContent.ts
@@ -56,6 +56,8 @@ export const hasMeaningfulServiceContent = (service: Service): boolean => {
     case "uptimekuma":
       // Uptime Kuma cards render persistent monitor stat tiles.
       return true;
+    case "whisparr":
+      return (service.stats?.whisparr?.queue?.totalRecords ?? 0) > 0;
     case "sonarr":
       return (service.stats?.sonarr?.queue?.totalRecords ?? 0) > 0;
     case "radarr":


### PR DESCRIPTION
Adds Whisparr as a supported service, matching the existing *arr integrations.

Whisparr V2 is a Sonarr V3 fork, so the service speaks `/api/v3` and authenticates with `X-Api-Key`. Queue records use the Sonarr-style series/episode query parameters. Default URL is `http://localhost:6969`.

## What's included

- Health checks, version display, and update notifications
- Queue visibility on the service card, with queue item removal
- CLI: `dashbrr service whisparr add|remove|list`
- Discovery via docker labels, k8s, and config file (`whisparr` type key)
- `DASHBRR_WHISPARR_API_KEY` environment variable support
- Docs: services matrix, commands, config management, README

## Notes

Whisparr defines its own queue types rather than sharing Sonarr's `QueueRecord`. The two are structurally identical today, but keeping them separate means Sonarr-side changes can't silently alter Whisparr behaviour — this also matches how Lidarr and Readarr are structured.

Tests pin the V2 API contract: `/api/v3` paths, the `X-Api-Key` header, the series/episode queue parameters, queue parsing, and 401 handling. A future drift toward the V3/Eros (Radarr-fork) shape will fail loudly rather than silently returning empty rows.

## Testing

Verified against a live Whisparr V2 instance — health, warnings, version, and a 10-item queue all rendering correctly on the service card.

- `go test -race -count=1 ./...`
- `golangci-lint run --new-from-merge-base=develop`
- `pnpm -C web lint typecheck test test:browser build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Whisparr as a supported media management service.
  * Added service discovery, API-key configuration, health checks, and queue monitoring.
  * Added CLI commands to list, add, and remove Whisparr services.
  * Added queue details, statistics, and queue-item deletion.
  * Added configuration guidance, including the default URL and API-key location.
* **Documentation**
  * Updated supported-service lists, configuration guidance, command examples, and the services matrix for Whisparr.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->