### PR TITLE
fix(discovery): make Kubernetes instance IDs unique

### DIFF
--- a/internal/services/discovery/kubernetes.go
+++ b/internal/services/discovery/kubernetes.go
@@ -100,7 +100,8 @@ func (k *KubernetesDiscovery) parseServiceAnnotations(annotations map[string]str
 		return nil, nil
 	}
 
-	instanceID := fmt.Sprintf("%s-k8s-%s-%s", parsed.serviceType, namespace, serviceName)
+	// Kubernetes namespaces and Service names cannot contain dots, so this boundary is unambiguous.
+	instanceID := fmt.Sprintf("%s-k8s-%s.%s", parsed.serviceType, namespace, serviceName)
 
 	return &models.ServiceConfiguration{
 		InstanceID:  instanceID,

--- a/internal/services/discovery/kubernetes.go
+++ b/internal/services/discovery/kubernetes.go
@@ -100,8 +100,7 @@ func (k *KubernetesDiscovery) parseServiceAnnotations(annotations map[string]str
 		return nil, nil
 	}
 
-	// Generate instance ID based on service type and namespace
-	instanceID := fmt.Sprintf("%s-k8s-%s", parsed.serviceType, namespace)
+	instanceID := fmt.Sprintf("%s-k8s-%s-%s", parsed.serviceType, namespace, serviceName)
 
 	return &models.ServiceConfiguration{
 		InstanceID:  instanceID,

--- a/internal/services/discovery/kubernetes_test.go
+++ b/internal/services/discovery/kubernetes_test.go
@@ -19,8 +19,8 @@ func TestParseServiceAnnotations_Valid(t *testing.T) {
 	if service == nil {
 		t.Fatalf("expected discovered service")
 	}
-	if service.InstanceID != "radarr-k8s-radarr-radarr" {
-		t.Fatalf("instance id = %q, want %q", service.InstanceID, "radarr-k8s-radarr-radarr")
+	if service.InstanceID != "radarr-k8s-radarr.radarr" {
+		t.Fatalf("instance id = %q, want %q", service.InstanceID, "radarr-k8s-radarr.radarr")
 	}
 	if service.URL != "http://radarr.radarr.svc.cluster.local:80" {
 		t.Fatalf("url = %q", service.URL)
@@ -47,10 +47,11 @@ func TestParseServiceAnnotations_InstanceID(t *testing.T) {
 		serviceName string
 		want        string
 	}{
-		{name: "same namespace first service", namespace: "media", serviceName: "sonarr", want: "sonarr-k8s-media-sonarr"},
-		{name: "same namespace second service", namespace: "media", serviceName: "sonarr-anime", want: "sonarr-k8s-media-sonarr-anime"},
-		{name: "same service again", namespace: "media", serviceName: "sonarr", want: "sonarr-k8s-media-sonarr"},
-		{name: "different namespace", namespace: "anime", serviceName: "sonarr", want: "sonarr-k8s-anime-sonarr"},
+		{name: "same namespace first service", namespace: "media", serviceName: "sonarr", want: "sonarr-k8s-media.sonarr"},
+		{name: "same namespace second service", namespace: "media", serviceName: "sonarr-anime", want: "sonarr-k8s-media.sonarr-anime"},
+		{name: "hyphen boundary collision", namespace: "media-sonarr", serviceName: "anime", want: "sonarr-k8s-media-sonarr.anime"},
+		{name: "same service again", namespace: "media", serviceName: "sonarr", want: "sonarr-k8s-media.sonarr"},
+		{name: "different namespace", namespace: "anime", serviceName: "sonarr", want: "sonarr-k8s-anime.sonarr"},
 	}
 
 	for _, tt := range tests {

--- a/internal/services/discovery/kubernetes_test.go
+++ b/internal/services/discovery/kubernetes_test.go
@@ -19,8 +19,8 @@ func TestParseServiceAnnotations_Valid(t *testing.T) {
 	if service == nil {
 		t.Fatalf("expected discovered service")
 	}
-	if service.InstanceID != "radarr-k8s-radarr" {
-		t.Fatalf("instance id = %q, want %q", service.InstanceID, "radarr-k8s-radarr")
+	if service.InstanceID != "radarr-k8s-radarr-radarr" {
+		t.Fatalf("instance id = %q, want %q", service.InstanceID, "radarr-k8s-radarr-radarr")
 	}
 	if service.URL != "http://radarr.radarr.svc.cluster.local:80" {
 		t.Fatalf("url = %q", service.URL)
@@ -30,6 +30,39 @@ func TestParseServiceAnnotations_Valid(t *testing.T) {
 	}
 	if service.DisplayName != "Movies" {
 		t.Fatalf("display name = %q", service.DisplayName)
+	}
+}
+
+func TestParseServiceAnnotations_InstanceID(t *testing.T) {
+	k := &KubernetesDiscovery{}
+	annotations := map[string]string{
+		GetLabelKey(labelTypeKey):   "sonarr",
+		GetLabelKey(labelURLKey):    "http://sonarr.media.svc.cluster.local:80",
+		GetLabelKey(labelAPIKeyKey): "key",
+	}
+
+	tests := []struct {
+		name        string
+		namespace   string
+		serviceName string
+		want        string
+	}{
+		{name: "same namespace first service", namespace: "media", serviceName: "sonarr", want: "sonarr-k8s-media-sonarr"},
+		{name: "same namespace second service", namespace: "media", serviceName: "sonarr-anime", want: "sonarr-k8s-media-sonarr-anime"},
+		{name: "same service again", namespace: "media", serviceName: "sonarr", want: "sonarr-k8s-media-sonarr"},
+		{name: "different namespace", namespace: "anime", serviceName: "sonarr", want: "sonarr-k8s-anime-sonarr"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service, err := k.parseServiceAnnotations(annotations, tt.namespace, tt.serviceName)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if service.InstanceID != tt.want {
+				t.Fatalf("instance id = %q, want %q", service.InstanceID, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- include the Kubernetes Service name in discovered instance IDs
- keep IDs stable for repeated discovery while separating Services by name and namespace
- add focused regression coverage for collisions and stable identity

Fixes #143

## Testing

- `go test -race -count=1 ./...`
- `pnpm -C web lint`
- `pnpm -C web typecheck`
- `pnpm -C web test`
- `pnpm -C web test:browser`
- `pnpm -C web build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Kubernetes service instance identifiers now use a dot between the namespace and service name.
  * Identifiers include the service type, namespace, and service name for improved clarity and distinction.

* **Bug Fixes**
  * Corrected identifier generation to consistently apply the updated format.
  * Existing discovered services may receive updated identifiers after this change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->