### PR TITLE
feat(database): support PostgreSQL DSNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ listen_addr = ":8080"
 type = "sqlite"
 path = "./data/dashbrr.db"
 
+# PostgreSQL can use a standard connection URI instead:
+# type = "postgres"
+# dsn = "postgres://dashbrr:password@postgres:5432/dashbrr?sslmode=require"
+
 [log]
 # trace, debug, info, warn, error, fatal, panic
 level = "info"

--- a/cmd/dashbrr/main.go
+++ b/cmd/dashbrr/main.go
@@ -120,34 +120,24 @@ func startServer(configPath string, listenAddr string, origDBPath string) error 
 		origDBPath = filepath.Join(configDir, "data", "dashbrr.db")
 	}
 
-	var cfg *config.Config
-	var err error
+	hasRequiredEnvVars := config.HasRequiredEnvVars()
+	log.Debug().Str("path", configPath).Msg("Loading config file")
 
-	if config.HasRequiredEnvVars() {
-		cfg = &config.Config{}
-		if err := config.LoadEnvOverrides(cfg); err != nil {
-			log.Error().Err(err).Msg("Failed to load environment variables")
-			return err
-		}
-	} else {
-		log.Debug().Str("path", configPath).Msg("Loading config file")
-
-		cfg, err = config.LoadConfig(configPath)
-		if err != nil {
-			log.Error().Err(err).Msg("Failed to load or create configuration")
-			return err
-		}
-
-		// Override with command line flags if they differ from defaults
-		if listenAddr != origListenAddr {
-			cfg.Server.ListenAddr = listenAddr
-		}
-		if origDBPath != "" {
-			cfg.Database.Path = origDBPath
-		}
+	cfg, err := config.LoadConfig(configPath)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to load or create configuration")
+		return err
 	}
 
-	db, err := database.InitDB(cfg.Database.Path)
+	// Override with command line flags if they differ from defaults
+	if !hasRequiredEnvVars && listenAddr != origListenAddr {
+		cfg.Server.ListenAddr = listenAddr
+	}
+	if !hasRequiredEnvVars && origDBPath != "" {
+		cfg.Database.Path = origDBPath
+	}
+
+	db, err := database.InitDBWithConfig(&cfg.Database)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to initialize database")
 		return err

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -76,6 +76,10 @@ Only needed if you serve the web UI from a different origin than the API (differ
 
 - `DASHBRR__DB_TYPE`
   - Set to: `"postgres"`
+- `DASHBRR__DB_DSN`
+  - Purpose: Standard PostgreSQL connection URI
+  - Example: `postgres://dashbrr:password@postgres:5432/dashbrr?sslmode=verify-full&sslrootcert=/certs/root.crt&sslcert=/certs/client.crt&sslkey=/certs/client.key`
+  - Optional. When set, this takes priority over the separate PostgreSQL settings below.
 - `DASHBRR__DB_HOST`
   - Purpose: PostgreSQL host address
   - Default: `postgres` (in Docker)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pelletier/go-toml/v2"
 	"github.com/rs/zerolog/log"
 
+	"github.com/autobrr/dashbrr/internal/database"
 	"github.com/autobrr/dashbrr/internal/logger"
 )
 
@@ -22,10 +23,10 @@ const (
 
 // Config represents the main configuration structure
 type Config struct {
-	Server   ServerConfig   `toml:"server"`
-	Database DatabaseConfig `toml:"database"`
-	Auth     AuthConfig     `toml:"auth"`
-	Log      LogConfig      `toml:"log"`
+	Server   ServerConfig    `toml:"server"`
+	Database database.Config `toml:"database"`
+	Auth     AuthConfig      `toml:"auth"`
+	Log      LogConfig       `toml:"log"`
 }
 
 // LogConfig holds logging-related configuration
@@ -41,17 +42,6 @@ type ServerConfig struct {
 	CORSMethods []string `toml:"cors_methods" env:"DASHBRR__CORS_METHODS"`
 	CORSMaxAgeH int      `toml:"cors_max_age_hours" env:"DASHBRR__CORS_MAX_AGE_HOURS"`
 	CORSCreds   *bool    `toml:"cors_allow_credentials" env:"DASHBRR__CORS_ALLOW_CREDENTIALS"`
-}
-
-// DatabaseConfig holds database-related configuration
-type DatabaseConfig struct {
-	Type     string `toml:"type" env:"DASHBRR__DB_TYPE"`
-	Path     string `toml:"path" env:"DASHBRR__DB_PATH"`
-	Host     string `toml:"host" env:"DASHBRR__DB_HOST"`
-	Port     int    `toml:"port" env:"DASHBRR__DB_PORT"`
-	User     string `toml:"user" env:"DASHBRR__DB_USER"`
-	Password string `toml:"password" env:"DASHBRR__DB_PASSWORD"`
-	Name     string `toml:"name" env:"DASHBRR__DB_NAME"`
 }
 
 // AuthConfig holds authentication-related configuration
@@ -84,11 +74,8 @@ func DefaultConfig() *Config {
 			// Defaults (can be overridden via env/config)
 			CORSMaxAgeH: 12,
 		},
-		Database: DatabaseConfig{
-			Type: "sqlite",
-			Path: "./data/dashbrr.db",
-		},
-		Log: LogConfig{Level: "info"},
+		Database: *database.DefaultConfig(),
+		Log:      LogConfig{Level: "info"},
 	}
 }
 
@@ -120,6 +107,9 @@ func HasRequiredEnvVars() bool {
 			return false
 		}
 	case "postgres":
+		if os.Getenv("DASHBRR__DB_DSN") != "" {
+			return true
+		}
 		requiredVars := []string{
 			"DASHBRR__DB_HOST",
 			"DASHBRR__DB_PORT",
@@ -143,13 +133,24 @@ func HasRequiredEnvVars() bool {
 func LoadConfig(path string) (*Config, error) {
 	config := &Config{}
 
-	// If all required environment variables are set, use them directly
+	// A PostgreSQL DSN takes priority over complete separate environment
+	// fields. Other complete environment configurations keep bypassing the file.
 	if HasRequiredEnvVars() {
+		if os.Getenv("DASHBRR__DB_TYPE") == "postgres" {
+			data, err := os.ReadFile(path)
+			fileConfig := DefaultConfig()
+			if err == nil && toml.Unmarshal(data, fileConfig) == nil && fileConfig.Database.DSN != "" {
+				config.Database.DSN = fileConfig.Database.DSN
+			}
+		}
+
 		if err := LoadEnvOverrides(config); err != nil {
 			return nil, fmt.Errorf("error loading environment variables: %w", err)
 		}
 		return config, nil
 	}
+
+	config = DefaultConfig()
 
 	// Otherwise try to load from config file
 	absPath, err := filepath.Abs(path)
@@ -163,8 +164,6 @@ func LoadConfig(path string) (*Config, error) {
 	if err != nil {
 		if os.IsNotExist(err) {
 			// Create default config
-			config = DefaultConfig()
-
 			// Ensure directory exists
 			if dir := filepath.Dir(absPath); dir != "" {
 				if err := os.MkdirAll(dir, 0755); err != nil {
@@ -253,30 +252,7 @@ func LoadEnvOverrides(config *Config) error {
 		}
 	}
 
-	// Database
-	if env := os.Getenv("DASHBRR__DB_TYPE"); env != "" {
-		config.Database.Type = env
-	}
-	if env := os.Getenv("DASHBRR__DB_PATH"); env != "" {
-		config.Database.Path = env
-	}
-	if env := os.Getenv("DASHBRR__DB_HOST"); env != "" {
-		config.Database.Host = env
-	}
-	if env := os.Getenv("DASHBRR__DB_PORT"); env != "" {
-		if port, err := strconv.Atoi(env); err == nil {
-			config.Database.Port = port
-		}
-	}
-	if env := os.Getenv("DASHBRR__DB_USER"); env != "" {
-		config.Database.User = env
-	}
-	if env := os.Getenv("DASHBRR__DB_PASSWORD"); env != "" {
-		config.Database.Password = env
-	}
-	if env := os.Getenv("DASHBRR__DB_NAME"); env != "" {
-		config.Database.Name = env
-	}
+	config.Database.ApplyEnvOverrides()
 
 	// Log
 	if env := os.Getenv("DASHBRR__LOG_LEVEL"); env != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -89,7 +89,14 @@ func TestDatabaseDSNTakesPriorityOverSeparateEnvironmentFields(t *testing.T) {
 }
 
 func TestPostgresConfigKeepsDefaultsAndEmptyPassword(t *testing.T) {
+	t.Setenv("DASHBRR__DB_TYPE", "")
+	t.Setenv("DASHBRR__DB_PATH", "")
+	t.Setenv("DASHBRR__DB_DSN", "")
+	t.Setenv("DASHBRR__DB_HOST", "")
+	t.Setenv("DASHBRR__DB_PORT", "")
+	t.Setenv("DASHBRR__DB_USER", "")
 	t.Setenv("DASHBRR__DB_PASSWORD", "")
+	t.Setenv("DASHBRR__DB_NAME", "")
 
 	cfg, err := LoadConfig(writeConfig(t, "[database]\ntype = \"postgres\"\n"))
 	if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -40,6 +40,117 @@ func TestOIDCFromTOML(t *testing.T) {
 	}
 }
 
+func TestDatabaseDSNFromTOML(t *testing.T) {
+	dsn := "postgres://db.example/dashbrr?sslmode=verify-full&sslrootcert=/certs/root.crt&sslcert=/certs/client.crt&sslkey=/certs/client.key"
+	cfg, err := LoadConfig(writeConfig(t, "[database]\ntype = \"postgres\"\ndsn = \""+dsn+"\"\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := cfg.Database.DSN; got != dsn {
+		t.Errorf("database DSN = %q, want %q", got, dsn)
+	}
+}
+
+func TestDatabaseDSNEnvOverridesTOML(t *testing.T) {
+	t.Setenv("DASHBRR__DB_DSN", "postgres://env.example/dashbrr?sslmode=require")
+
+	cfg, err := LoadConfig(writeConfig(t, "[database]\ntype = \"postgres\"\ndsn = \"postgres://toml.example/dashbrr?sslmode=disable\"\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := cfg.Database.DSN; got != "postgres://env.example/dashbrr?sslmode=require" {
+		t.Errorf("database DSN = %q, want the value from the environment", got)
+	}
+}
+
+func TestDatabaseDSNTakesPriorityOverSeparateEnvironmentFields(t *testing.T) {
+	t.Setenv("DASHBRR__LISTEN_ADDR", ":8080")
+	t.Setenv("DASHBRR__DB_TYPE", "postgres")
+	t.Setenv("DASHBRR__DB_HOST", "env-db.example")
+	t.Setenv("DASHBRR__DB_PORT", "5432")
+	t.Setenv("DASHBRR__DB_USER", "env-user")
+	t.Setenv("DASHBRR__DB_PASSWORD", "env-password")
+	t.Setenv("DASHBRR__DB_NAME", "env-database")
+
+	want := "postgres://toml.example/dashbrr?sslmode=require"
+	cfg, err := LoadConfig(writeConfig(t, "[database]\ntype = \"postgres\"\ndsn = \""+want+"\"\n"+oidcTOML))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := cfg.Database.DSN; got != want {
+		t.Errorf("database DSN = %q, want %q", got, want)
+	}
+	if cfg.Auth.OIDC.IsConfigured() {
+		t.Error("unrelated TOML settings loaded with the database DSN")
+	}
+}
+
+func TestPostgresConfigKeepsDefaultsAndEmptyPassword(t *testing.T) {
+	t.Setenv("DASHBRR__DB_PASSWORD", "")
+
+	cfg, err := LoadConfig(writeConfig(t, "[database]\ntype = \"postgres\"\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Database.Host != "localhost" || cfg.Database.Port != 5432 || cfg.Database.User != "dashbrr" || cfg.Database.DBName != "dashbrr" {
+		t.Errorf("database defaults not preserved: %#v", cfg.Database)
+	}
+	if cfg.Database.Password != "" {
+		t.Errorf("database password = %q, want explicit empty value", cfg.Database.Password)
+	}
+}
+
+func TestHasRequiredEnvVarsWithDatabaseDSN(t *testing.T) {
+	t.Setenv("DASHBRR__LISTEN_ADDR", ":8080")
+	t.Setenv("DASHBRR__DB_TYPE", "postgres")
+	t.Setenv("DASHBRR__DB_DSN", "postgres://db.example/dashbrr?sslmode=require")
+	t.Setenv("DASHBRR__DB_HOST", "")
+	t.Setenv("DASHBRR__DB_PORT", "")
+	t.Setenv("DASHBRR__DB_USER", "")
+	t.Setenv("DASHBRR__DB_PASSWORD", "")
+	t.Setenv("DASHBRR__DB_NAME", "")
+
+	if !HasRequiredEnvVars() {
+		t.Error("HasRequiredEnvVars() = false, want true for PostgreSQL DSN")
+	}
+}
+
+func TestCompleteSQLiteEnvironmentIgnoresConfigFile(t *testing.T) {
+	t.Setenv("DASHBRR__LISTEN_ADDR", ":8080")
+	t.Setenv("DASHBRR__DB_TYPE", "sqlite")
+	t.Setenv("DASHBRR__DB_PATH", "/data/env.db")
+
+	cfg, err := LoadConfig(writeConfig(t, "not valid toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cfg.Database.Path; got != "/data/env.db" {
+		t.Errorf("database path = %q, want the value from the environment", got)
+	}
+}
+
+func TestCompletePostgresEnvironmentIgnoresTOMLWithoutDSN(t *testing.T) {
+	t.Setenv("DASHBRR__LISTEN_ADDR", ":8080")
+	t.Setenv("DASHBRR__DB_TYPE", "postgres")
+	t.Setenv("DASHBRR__DB_HOST", "env-db.example")
+	t.Setenv("DASHBRR__DB_PORT", "5432")
+	t.Setenv("DASHBRR__DB_USER", "env-user")
+	t.Setenv("DASHBRR__DB_PASSWORD", "env-password")
+	t.Setenv("DASHBRR__DB_NAME", "env-database")
+
+	cfg, err := LoadConfig(writeConfig(t, oidcTOML))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Auth.OIDC.IsConfigured() {
+		t.Error("OIDC config loaded from TOML in a complete environment-only setup")
+	}
+}
+
 func TestOIDCEnvOverridesTOML(t *testing.T) {
 	t.Setenv("DASHBRR__OIDC_ISSUER", "https://env.example.com")
 

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -9,10 +9,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
-	_ "github.com/lib/pq"
+	"github.com/lib/pq"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	_ "modernc.org/sqlite"
@@ -34,37 +35,64 @@ type DB struct {
 
 // Config holds database configuration
 type Config struct {
-	Driver   string
-	Host     string
-	Port     string
-	User     string
-	Password string
-	DBName   string
-	Path     string // For SQLite
+	Driver   string `toml:"type" env:"DASHBRR__DB_TYPE"`
+	Path     string `toml:"path" env:"DASHBRR__DB_PATH"`
+	DSN      string `toml:"dsn" env:"DASHBRR__DB_DSN"`
+	Host     string `toml:"host" env:"DASHBRR__DB_HOST"`
+	Port     int    `toml:"port" env:"DASHBRR__DB_PORT"`
+	User     string `toml:"user" env:"DASHBRR__DB_USER"`
+	Password string `toml:"password" env:"DASHBRR__DB_PASSWORD"`
+	DBName   string `toml:"name" env:"DASHBRR__DB_NAME"`
 }
 
-// NewConfig creates a new database configuration from environment variables
+// DefaultConfig returns the default database configuration.
+func DefaultConfig() *Config {
+	return &Config{
+		Driver:   "sqlite",
+		Path:     "./data/dashbrr.db",
+		Host:     "localhost",
+		Port:     5432,
+		User:     "dashbrr",
+		Password: "dashbrr",
+		DBName:   "dashbrr",
+	}
+}
+
+// NewConfig creates a new database configuration from environment variables.
 func NewConfig() *Config {
-	dbType := os.Getenv("DASHBRR__DB_TYPE")
-	if dbType == "" {
-		dbType = "sqlite" // Default to SQLite
-	}
-
-	config := &Config{
-		Driver: dbType,
-	}
-
-	if dbType == "postgres" {
-		config.Host = getEnv("DASHBRR__DB_HOST", "localhost")
-		config.Port = getEnv("DASHBRR__DB_PORT", "5432")
-		config.User = getEnv("DASHBRR__DB_USER", "dashbrr")
-		config.Password = getEnv("DASHBRR__DB_PASSWORD", "dashbrr")
-		config.DBName = getEnv("DASHBRR__DB_NAME", "dashbrr")
-	} else {
-		config.Path = getEnv("DASHBRR__DB_PATH", "./data/dashbrr.db")
-	}
-
+	config := DefaultConfig()
+	config.ApplyEnvOverrides()
 	return config
+}
+
+// ApplyEnvOverrides applies database environment variables to config.
+func (config *Config) ApplyEnvOverrides() {
+	if env := os.Getenv("DASHBRR__DB_TYPE"); env != "" {
+		config.Driver = env
+	}
+	if env := os.Getenv("DASHBRR__DB_PATH"); env != "" {
+		config.Path = env
+	}
+	if env := os.Getenv("DASHBRR__DB_DSN"); env != "" {
+		config.DSN = env
+	}
+	if env := os.Getenv("DASHBRR__DB_HOST"); env != "" {
+		config.Host = env
+	}
+	if env := os.Getenv("DASHBRR__DB_PORT"); env != "" {
+		if port, err := strconv.Atoi(env); err == nil {
+			config.Port = port
+		}
+	}
+	if env := os.Getenv("DASHBRR__DB_USER"); env != "" {
+		config.User = env
+	}
+	if env, exists := os.LookupEnv("DASHBRR__DB_PASSWORD"); exists {
+		config.Password = env
+	}
+	if env := os.Getenv("DASHBRR__DB_NAME"); env != "" {
+		config.DBName = env
+	}
 }
 
 // InitDB initializes the database connection and performs migrations
@@ -200,31 +228,29 @@ func (db *DB) openPostgres() error {
 	maxRetries := 5
 	baseDelay := time.Second
 
-	// PostgreSQL connection
-	dsn := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=disable",
-		db.config.Host, db.config.Port, db.config.User, db.config.Password, db.config.DBName)
+	dsn := postgresDSN(db.config)
 
 	log.Debug().
 		Str("host", db.config.Host).
-		Str("port", db.config.Port).
+		Int("port", db.config.Port).
 		Str("database", db.config.DBName).
 		Msg("Initializing PostgreSQL database")
 
-	var database *sql.DB
-	var err error
+	connector, err := pq.NewConnector(dsn)
+	if err != nil {
+		return errors.New("invalid PostgreSQL connection configuration")
+	}
+	database := sql.OpenDB(connector)
 
 	// Retry loop with exponential backoff
 	for attempt := 1; attempt <= maxRetries; attempt++ {
-		database, err = sql.Open("postgres", dsn)
+		err = database.PingContext(context.Background())
 		if err == nil {
-			// Test the connection
-			err = database.Ping()
-			if err == nil {
-				break // Successfully connected
-			}
+			break // Successfully connected
 		}
 
 		if attempt == maxRetries {
+			_ = database.Close()
 			return fmt.Errorf("failed to connect to database after %d attempts: %w", maxRetries, err)
 		}
 
@@ -253,12 +279,13 @@ func (db *DB) openPostgres() error {
 	return nil
 }
 
-// getEnv retrieves an environment variable with a fallback value
-func getEnv(key, fallback string) string {
-	if value, exists := os.LookupEnv(key); exists {
-		return value
+func postgresDSN(config *Config) string {
+	if config.DSN != "" {
+		return config.DSN
 	}
-	return fallback
+
+	return fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable",
+		config.Host, config.Port, config.User, config.Password, config.DBName)
 }
 
 // HasUsers checks if any users exist in the database

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -6,6 +6,7 @@ package database
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -65,6 +66,65 @@ func TestDatabaseInitialization(t *testing.T) {
 	// We expect at least the users and service_configurations tables
 	if tableCount < 2 {
 		t.Errorf("Expected at least 2 tables, got %d", tableCount)
+	}
+}
+
+func TestPostgresDSN(t *testing.T) {
+	uri := "postgres://db.example/dashbrr?sslmode=verify-full&sslrootcert=/certs/root.crt&sslcert=/certs/client.crt&sslkey=/certs/client.key"
+	tests := []struct {
+		name   string
+		config *Config
+		want   string
+	}{
+		{
+			name:   "configured URI",
+			config: &Config{DSN: uri},
+			want:   uri,
+		},
+		{
+			name: "separate fields",
+			config: &Config{
+				Host: "db.example", Port: 5432, User: "dashbrr", Password: "secret", DBName: "dashbrr",
+			},
+			want: "host=db.example port=5432 user=dashbrr password=secret dbname=dashbrr sslmode=disable",
+		},
+		{
+			name: "empty password",
+			config: &Config{
+				Host: "db.example", Port: 5432, User: "dashbrr", DBName: "dashbrr",
+			},
+			want: "host=db.example port=5432 user=dashbrr password= dbname=dashbrr sslmode=disable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := postgresDSN(tt.config); got != tt.want {
+				t.Errorf("postgresDSN() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewConfigReadsPostgresDSN(t *testing.T) {
+	t.Setenv("DASHBRR__DB_TYPE", "postgres")
+	t.Setenv("DASHBRR__DB_DSN", "postgres://db.example/dashbrr?sslmode=require")
+
+	if got := NewConfig().DSN; got != "postgres://db.example/dashbrr?sslmode=require" {
+		t.Errorf("database DSN = %q, want the value from the environment", got)
+	}
+}
+
+func TestPostgresErrorsDoNotExposeDSNCredentials(t *testing.T) {
+	const secret = "client-secret"
+	db := &DB{config: &Config{DSN: "postgres://client:" + secret + "@db.example/%zz"}}
+
+	err := db.openPostgres()
+	if err == nil {
+		t.Fatal("openPostgres() error = nil, want invalid DSN error")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Errorf("openPostgres() error exposes DSN credentials: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- accept PostgreSQL connection URIs from `database.dsn` and `DASHBRR__DB_DSN`
- preserve URI TLS parameters while keeping the existing separate-field fallback and defaults
- keep DSN credentials out of logs, including malformed-URI errors

## Testing

- `make precommit`
- `go test -race -count=1 ./...`
- `pnpm -C web lint`
- `pnpm -C web typecheck`
- `pnpm -C web test`
- `pnpm -C web test:browser`
- `pnpm -C web build`

Closes #141