### PR TITLE
fix(tailscale): return GetDevices error on stored-config path

### DIFF
--- a/internal/api/handlers/tailscale.go
+++ b/internal/api/handlers/tailscale.go
@@ -111,9 +111,9 @@ func (h *TailscaleHandler) GetTailscaleDevices(c *gin.Context) {
 			if apiKey != "" {
 				devices, err = service.GetDevices(ctx, "", apiKey)
 			} else {
-				tailscaleConfig, err := requireServiceConfig(ctx, h.db, instanceId, "tailscale")
-				if err != nil {
-					return tailscaleDevicesResponse{}, err
+				tailscaleConfig, cfgErr := requireServiceConfig(ctx, h.db, instanceId, "tailscale")
+				if cfgErr != nil {
+					return tailscaleDevicesResponse{}, cfgErr
 				}
 				devices, err = service.GetDevices(ctx, "", tailscaleConfig.APIKey)
 			}

--- a/internal/api/handlers/tailscale.go
+++ b/internal/api/handlers/tailscale.go
@@ -106,17 +106,15 @@ func (h *TailscaleHandler) GetTailscaleDevices(c *gin.Context) {
 		Fetch: func() (tailscaleDevicesResponse, error) {
 			service := &tailscale.TailscaleService{}
 
-			var devices []tailscale.Device
-			var err error
-			if apiKey != "" {
-				devices, err = service.GetDevices(ctx, "", apiKey)
-			} else {
-				tailscaleConfig, cfgErr := requireServiceConfig(ctx, h.db, instanceId, "tailscale")
-				if cfgErr != nil {
-					return tailscaleDevicesResponse{}, cfgErr
+			key := apiKey
+			if key == "" {
+				tailscaleConfig, err := requireServiceConfig(ctx, h.db, instanceId, "tailscale")
+				if err != nil {
+					return tailscaleDevicesResponse{}, err
 				}
-				devices, err = service.GetDevices(ctx, "", tailscaleConfig.APIKey)
+				key = tailscaleConfig.APIKey
 			}
+			devices, err := service.GetDevices(ctx, "", key)
 			if err != nil {
 				return tailscaleDevicesResponse{}, err
 			}


### PR DESCRIPTION
In `GetTailscaleDevices` the `else` branch declares a new `err` with `:=`:

```go
var devices []tailscale.Device
var err error
if apiKey != "" {
    devices, err = service.GetDevices(ctx, "", apiKey)
} else {
    tailscaleConfig, err := requireServiceConfig(ctx, h.db, instanceId, "tailscale")  // new err
    if err != nil {
        return tailscaleDevicesResponse{}, err
    }
    devices, err = service.GetDevices(ctx, "", tailscaleConfig.APIKey)  // assigns the inner err
}
if err != nil {   // outer err, still nil on this path
```

`devices, err = ...` inside the block assigns the shadowed `err`, so the check after the block reads the outer one, which nothing on that path ever writes to. A `GetDevices` failure when falling back to the stored config is therefore swallowed, and since `devices` is then nil the `devices == nil` branch just below turns it into an empty list. The handler returns 200 with zero devices instead of the error.

The `apiKey != ""` path is unaffected, which is probably why this has not shown up: it only bites when no explicit API key is passed and the stored config is used.

Renaming the config error to `cfgErr` leaves the outer `err` as the one `GetDevices` writes to on both paths, so the existing check does its job. staticcheck flags the original as SA4006.

Verified: `go build ./...` passes, `go test ./internal/...` green, `gofmt -l` clean on the touched file, SA4006 gone under `GOOS=linux` and `GOOS=darwin`.

Unrelated and not touched, but noticed nearby: `internal/services/tailscale/tailscale.go:148` drops the error from `GetCachedVersion` before overwriting `err` on the next line, so a failed version lookup silently reports an empty `version` in the health extras. Left alone since whether that should be fatal is your call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Tailscale device retrieval by consistently using the provided API key when available and falling back to the instance configuration when needed.
  * Preserved configuration validation and existing behavior for successful device lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->